### PR TITLE
[Migration] Revive the QuickChick differential testings against the Vellvm main branch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,4 @@ RocqMakefile.conf
 CLAUDE.md
 cleanup_survey.md
 genllvm
+.claude/

--- a/src/Makefile
+++ b/src/Makefile
@@ -15,7 +15,7 @@ VELLVM_ROCQ_DIR = $(VELLVM_SRC_DIR)/rocq
 VELLVM_ML_DIR = $(VELLVM_SRC_DIR)/ml
 
 
-ROCQINCLUDES=$(ROCQDIR), -R $(ROCQDIR) GenLLVM -R $(EXTRACTDIR) Extract -R Vellvm $(VELLVM_ROCQ_DIR)
+ROCQINCLUDES=-R $(ROCQDIR) GenLLVM -R $(EXTRACTDIR) Extract -R $(VELLVM_ROCQ_DIR) Vellvm
 ROCQEXEC="$(ROCQBIN)rocq" top -q -w none $(ROCQINCLUDES) -batch -load-vernac-source
 ROCQMAKEFILE="$(ROCQBIN)rocq" makefile
 
@@ -38,7 +38,7 @@ RocqMakefile: _RocqProject
 all:
 	$(MAKE) vellvm
 	$(MAKE) rocq
-	$(MAKE) genllvm
+#	$(MAKE) genllvm
 
 .PHONY: rocq
 rocq: real-all
@@ -49,7 +49,18 @@ rocq: real-all
 vellvm:
 	make interp -C ../vellvm/src 
 
+######## QuickChick testing targets
 
+.PHONY: qc-tests
+qc-tests: rm-qc-test-vo vellvm qc-files
+	$(ROCQEXEC) rocq/QCVellvm.v
+
+.PHONY: qc-files
+qc-files: rocq
+
+.PHONY: rm-qc-test-vo
+rm-qc-test-vo:
+	rm -f rocq/QCVellvm.vo rocq/QCVellvm.vos rocq/QCVellvm.vok rocq/QCVellvm.glob rocq/.QCVellvm.aux
 
 .PHONY: extracted
 extracted: $(EXTRACTDIR)/STAMP

--- a/src/_RocqProject
+++ b/src/_RocqProject
@@ -6,11 +6,16 @@
 -arg -w -arg -deprecated-hint-rewrite-without-locality
 -arg -w -arg -require-in-module
 
-./rocq/GenAST.v
+./rocq/Lens.v
+./rocq/Default.v
+./rocq/ECS.v
+./rocq/GenMetadata.v
+./rocq/Utils.v
 ./rocq/Generators.v
+./rocq/GenAST.v
 ./rocq/GenLLVM.v
 ./rocq/QCVellvm.v
 ./rocq/TestCases.v
-./rocq/Utils.v
+
 
 

--- a/src/_RocqProject
+++ b/src/_RocqProject
@@ -12,6 +12,7 @@
 ./rocq/GenMetadata.v
 ./rocq/Utils.v
 ./rocq/Generators.v
+./rocq/TypeUtil.v
 ./rocq/GenAST.v
 ./rocq/GenLLVM.v
 ./rocq/QCVellvm.v

--- a/src/_RocqProject
+++ b/src/_RocqProject
@@ -6,6 +6,7 @@
 -arg -w -arg -deprecated-hint-rewrite-without-locality
 -arg -w -arg -require-in-module
 
+./rocq/QCExtractionFix.v
 ./rocq/Lens.v
 ./rocq/Default.v
 ./rocq/ECS.v
@@ -15,8 +16,6 @@
 ./rocq/TypeUtil.v
 ./rocq/GenAST.v
 ./rocq/GenLLVM.v
-./rocq/QCVellvm.v
-./rocq/TestCases.v
 
 
 

--- a/src/rocq/Default.v
+++ b/src/rocq/Default.v
@@ -1,0 +1,19 @@
+From Stdlib Require Import ZArith List.
+
+Import ListNotations.
+
+Class Default A : Type :=
+  { def : A
+  }.
+
+Instance DefaultN : Default N :=
+  { def := 0 }.
+
+Instance DefaultNat : Default nat :=
+  { def := 0 }.
+
+Instance DefaultZ : Default Z :=
+  { def := 0 }.
+
+Instance DefaultList {A} : Default (list A) :=
+  { def := [] }.

--- a/src/rocq/ECS.v
+++ b/src/rocq/ECS.v
@@ -1,0 +1,371 @@
+(* Heavily inspired by https://reasonablypolymorphic.com/blog/why-take-ecstasy/index.html *)
+
+From Stdlib Require Import List.
+From Ltac2 Require Import Ltac2.
+From Stdlib Require Import ZArith String.
+From Vellvm.Utils Require Import
+  IntMaps
+  Monads
+  Default.
+
+From Vellvm.QC Require Import Lens.
+Import LensNotations.
+Local Open Scope lens.
+
+Require Import ExtLib.Data.Monads.StateMonad.
+Require Import ExtLib.Data.Monads.OptionMonad.
+Require Import ExtLib.Data.Monads.ReaderMonad.
+Require Import ExtLib.Structures.Monads.
+Require Import ExtLib.Structures.Functor.
+Require Import ExtLib.Structures.Applicative.
+Require Import ExtLib.Structures.Traversable.
+Require Import ExtLib.Structures.Foldable.
+Require Import ExtLib.Structures.MonadPlus.
+Import MonadNotation.
+Import MonadPlusNotation.
+Import ApplicativeNotation.
+Import FunctorNotation.
+Import ListNotations.
+
+Definition Position := (Z * Z)%type.
+
+Variant ComponentType :=
+  | Field
+  | Unique.
+
+Variant StorageType :=
+  | FieldOf
+  | WorldOf : (Type -> Type) -> StorageType
+  | SetterOf.
+
+Variant Update (a : Type) :=
+  | Keep
+  | Unset
+  | SetValue : a -> Update a.
+
+#[global] Instance Default_Update {a} : Default (Update a).
+split.
+apply Keep.
+Defined.
+
+#[global] Instance Functor_Update : Functor Update.
+split.
+intros A B f ua.
+destruct ua eqn:Hua.
+- apply Keep.
+- apply Unset.
+- apply (SetValue _ (f a)).
+Defined.
+
+(* TODO: Move to intmap library *)
+#[global] Instance Functor_IntMap : Functor IntMap.
+split.
+intros A B f ma.
+eapply IntMaps.IM.map. apply f.
+apply ma.
+Defined.
+
+(* TODO: Move to intmap library *)
+#[global] Instance Functor_IntMapRaw : Functor IM.Raw.t.
+split.
+intros A B f ma.
+eapply IM.Raw.map. apply f.
+apply ma.
+Defined.
+
+
+Record Ent := mkEnt { unEnt : Z }.
+
+Definition Component (s : StorageType) (c : ComponentType) (a : Type) : Type :=
+  match s with
+  | FieldOf => option a
+  | SetterOf => Update a
+  | WorldOf m =>
+      match c with
+      | Field => IM.Raw.t a
+      | Unique => option (Z * a)
+      end
+  end.
+
+#[global] Instance Functor_Component {s c} : Functor (Component s c).
+split.
+intros A B f.
+destruct s.
+- apply (fmap f).
+- destruct c; cbn.
+  + apply (fmap f).
+  + intros o.
+    destruct o eqn:Ho.
+    * destruct p.
+      apply (Some (z, f a)).
+    * apply None.
+- cbn.
+  apply (fmap f).
+Defined.
+
+Record SystemState w m :=
+  mkSystemState
+  { systemStateNextEnt : Z
+  ; systemStateEntities : IS.t
+  ; systemStateMetadata : w (WorldOf m)
+  }.
+
+#[global] Instance Default_IntSet : Default IS.t
+  := { def := IS.empty }.
+
+#[global] Instance Default_IntMapRaw {e} : Default (@IM.Raw.t e)
+  := { def := IM.Raw.empty _ }.
+
+#[global] Instance Default_SystemState {w m} `{Default (w (WorldOf m))} : Default (SystemState w m)
+  := { def := mkSystemState w m def def def }.
+
+Class EntityStore (Store : Type) : Type := 
+  { nextEnt : Lens' Store Z
+  ; entities : Lens' Store IS.t
+  }.
+
+Definition nextEntSystem {w m} : Lens' (SystemState w m) Z.
+  red.
+  intros f F afa w'.
+
+  refine
+    open_constr:
+      ((fun x => _) <$> afa (_ w')); try typeclasses_eauto.
+  - constructor;
+      Control.dispatch
+        [ (fun _ => apply x)
+          ; (fun _ => eapply systemStateEntities)
+          ; (fun _ => eapply systemStateMetadata)
+        ];
+      apply w'.
+  - intros w''.
+    destruct w''.
+    apply systemStateNextEnt0.
+Defined.
+
+Definition entitiesSystem {w m} : Lens' (SystemState w m) IS.t.
+  red.
+  intros f F afa w'.
+
+  refine
+    open_constr:
+      ((fun x => _) <$> afa (_ w')); try typeclasses_eauto.
+  - constructor;
+      Control.dispatch
+        [ (fun _ => eapply systemStateNextEnt)
+          ; (fun _ => eapply x)
+          ; (fun _ => eapply systemStateMetadata)
+        ];
+      apply w'.
+  - intros w''.
+    destruct w''.
+    apply systemStateEntities0.
+Defined.
+
+#[global] Instance EntityStore_SystemState {w m} : EntityStore (SystemState w m).
+split.
+apply nextEntSystem.
+apply entitiesSystem.
+Defined.
+
+Class MetadataStore {m} (Meta : StorageType -> Type) (Store : Type) : Type :=
+  { metadata : Lens' Store (Meta (WorldOf m))
+  }.
+
+#[global] Instance MetadataStore_SystemState {w m} : @MetadataStore m w (SystemState w m).
+split.
+red.
+intros f F afa w'.
+
+refine
+  open_constr:
+    ((fun x => _) <$> afa (_ w')); try typeclasses_eauto.
+- constructor;
+    Control.dispatch
+      [ (fun _ => eapply systemStateNextEnt)
+        ; (fun _ => eapply systemStateEntities)
+        ; (fun _ => eapply x)
+      ];
+    apply w'.
+- intros w''.
+  destruct w''.
+  apply systemStateMetadata0.
+Defined.
+
+Definition SystemT W M A := stateT (SystemState W M) M A.
+#[global] Instance Monad_SystemT {w} {m} `{Monad m} : Monad (SystemT w m).
+unfold SystemT.
+apply Monad_stateT; auto.
+Defined.
+
+#[global] Instance MonadState_SystemT {w} {m} `{Monad m} : MonadState (SystemState w m) (SystemT w m).
+unfold SystemT.
+apply MonadState_stateT; auto.
+Defined.
+
+#[global] Instance MonadT_SystemT {w} {m} `{Monad m} : MonadT (SystemT w m) m.
+unfold SystemT.
+apply MonadT_stateT; auto.
+Defined.
+
+Definition updateIntMap {a} (u : Update a) k (m : IntMap a) : IntMap a
+  := match u with
+     | Keep => m
+     | Unset => delete k m
+     | SetValue x => add k x m
+     end.
+
+Definition updateIntMapRaw {a} (u : Update a) k (m : IM.Raw.t a) : IM.Raw.t a
+  := match u with
+     | Keep => m
+     | Unset => IM.Raw.remove k m
+     | SetValue x => IM.Raw.add k x m
+     end.
+
+Definition optionToUpdate {a} (v : option a) : Update a :=
+  match v with
+  | Some x => SetValue _ x
+  | None => Keep _
+  end.
+
+#[global] Instance Traversable_option : Traversable option.
+split.
+intros F Ap A B X X0.
+destruct X0 eqn:Hx.
+- apply (Some <$> X a).
+- apply (pure None).
+Defined.
+
+#[global] Instance Traversable_Update : Traversable Update.
+split.
+intros F Ap A B X X0.
+destruct X0 eqn:Hx.
+- apply (pure (Keep _)).
+- apply (pure (Unset _)).
+- apply (SetValue _ <$> X a).
+Defined.
+
+#[global] Instance Traversable_Component {s c} : Traversable (Component s c).
+split.
+intros F Ap A B X X0.
+destruct s; cbn in *.
+- eapply mapT; eauto.
+- destruct c.
+  + eapply mapT; eauto.
+  + eapply mapT.
+    2: apply X0.
+    intros X1.
+    eapply ap.
+    2: apply (X (snd X1)).
+    apply (pure (fun b => (fst X1, b))).
+- eapply mapT; eauto.
+Defined.
+
+Definition optSetMap {a} (mv : option a) k (m : IntMap a) : IntMap a
+  := match mv with
+     | Some v => add k v m
+     | None => delete k m
+     end.
+
+Definition optSetMapRaw {a} (mv : option a) k (m : IM.Raw.t a) : IM.Raw.t a
+  := match mv with
+     | Some v => IM.Raw.add k v m
+     | None => IM.Raw.remove k m
+     end.
+
+Definition newEntity {w} {m} `{Monad m} : SystemT w m Ent
+  := i <- use nextEnt;;
+     nextEnt .= Z.succ i;;
+     entities %= (fun ents => IS.add i ents);;
+     ret (mkEnt i).
+
+Definition runSystemT {w m} `{Default (w (WorldOf m))} `{Monad m} {a} (sys : SystemT w m a) : m a
+  := evalStateT sys def.
+
+Definition ixs {a} `{Default a} (ns : list nat) : Traversal (list a) (list a) a a.
+  red.
+  intros f F focus xs.
+  refine constr:(let fix go (n : nat) (ns : list nat) (xs : list a) :=
+            match xs with
+            | nil => pure nil
+            | cons a0 l =>
+                let rest := go (S n) ns l in
+                if (existsb (Nat.eqb n) ns)
+                then (pure cons <*> focus a0 <*> rest)
+                else (pure cons <*> pure a0 <*> rest)
+            end
+          in
+          go 0 ns xs).
+Defined.
+
+Record QueryT w m a : Type :=
+  mkQueryT
+  { runQueryT' : readerT (Ent * w FieldOf) (optionT m) a
+  }.
+
+Arguments runQueryT' {_ _ _}.
+
+#[global] Instance Monad_QueryT {w m} `{Monad m} : Monad (QueryT w m).
+split.
+- intros t X.
+  apply mkQueryT.
+  apply (ret X).
+- intros A B qa k.
+  apply mkQueryT.
+  eapply bind.
+  apply qa.
+  apply k.
+Defined.
+
+#[global] Instance MonadZero_QueryT {w m} `{Monad m} : MonadZero (QueryT w m).
+split.
+intros T.
+apply mkQueryT.
+apply mzero.
+Defined.
+
+Definition unQueryT {w m a} (q : QueryT w m a)  (e : Ent) (meta : w FieldOf) : m (option a)
+  := unOptionT (runReaderT (runQueryT' q) (e, meta)).
+
+Definition query {world a m} `{Monad m} (f : world FieldOf -> option a) : QueryT world m a
+  := e <- @mkQueryT world m _ (asks snd);;
+     match f e with
+     | None => mzero
+     | Some x => ret x
+     end.
+
+Definition queryl {world a m} `{Monad m} (l : Lens' (world FieldOf) (Component FieldOf Field a)) : QueryT world m a
+  := query (view l).
+
+Definition withq {world a m} `{Monad m} (f : world FieldOf -> option a) : QueryT world m unit
+  := query f;;
+     ret tt.
+
+Definition withl {world a m} `{Monad m} (l : Lens' (world FieldOf) (Component FieldOf Field a)) : QueryT world m unit
+  := withq (view l).
+
+Definition without {world a m} `{Monad m} (f : world FieldOf -> option a) : QueryT world m unit
+  := e <- @mkQueryT world m _ (asks snd);;
+     match f e with
+     | None => ret tt
+     | Some x => mzero
+     end.
+
+Definition withoutl {world a m} `{Monad m} (l : Lens' (world FieldOf) (Component FieldOf Field a)) : QueryT world m unit
+  := without (view l).
+
+(* I want to be able to use `IS.t` and `IM.Raw.t unit` and maybe `list Z` and `list Ent` as targets... What do I need from an EntTarget? *)
+Class ToEnt T :=
+  { toEnt : T -> Ent
+  }.
+
+#[global] Instance ToEnt_Z : ToEnt Z :=
+  { toEnt := mkEnt }.
+
+#[global] Instance ToEnt_Ent : ToEnt Ent :=
+  { toEnt := id }.
+
+Definition EntTarget {es E} `{ToEnt E} `{Foldable es E} w m := SystemT w m es.
+
+Definition allEnts {w m} `{Monad m} : EntTarget w m (es:=IS.t)
+  := use entities.

--- a/src/rocq/ECS.v
+++ b/src/rocq/ECS.v
@@ -5,12 +5,11 @@ From Ltac2 Require Import Ltac2.
 From Stdlib Require Import ZArith String.
 From Vellvm.Utils Require Import
   IntMaps
-  Monads
-  Default.
+  ListUtil.
 
-From Vellvm.QC Require Import Lens.
+From GenLLVM Require Import Lens Default.
 Import LensNotations.
-Local Open Scope lens.
+#[local] Open Scope lens.
 
 Require Import ExtLib.Data.Monads.StateMonad.
 Require Import ExtLib.Data.Monads.OptionMonad.

--- a/src/rocq/GenAST.v
+++ b/src/rocq/GenAST.v
@@ -102,7 +102,7 @@ Section Helpers.
        | TYPE_Void => false
        | TYPE_FP _ => true
        | TYPE_Label => true
-       | TYPE_Token => true                          
+       | TYPE_Token => true
        | TYPE_Metadata => true (* Not sure if this is right *)
        | TYPE_X86_mmx => true
        | TYPE_Array sz t => is_sized_type_h t
@@ -1708,7 +1708,7 @@ Section ExpGenerators.
            identified types... It should be conservative and say that
            the types are *not* equal always, though.
    *)
-  
+
   Fixpoint normalized_typ_eq (a : typ) (b : typ) {struct a} : bool
     := match a with
        | TYPE_I sz =>
@@ -1910,7 +1910,7 @@ Section ExpGenerators.
   (* Can't use choose for these functions because it gets extracted to
      ocaml's Random.State.int function which has small bounds. *)
 
-  
+
   Definition gen_int (sz : N) : G Z :=
     let i_sz := Z.of_N sz in
     if (i_sz <=? 8)%Z then (choose (0, 2 ^ i_sz - 1)) else ret 10000.
@@ -1986,7 +1986,7 @@ Section ExpGenerators.
   Definition gen_gt_zero_exp (bitwidth : option positive) : G (exp typ) :=
     i_val <- gen_gt_zero bitwidth;;
     (ret (EXP_Integer (BinIntDef.Z.to_num_int i_val))).
-    
+
   (* Generates a random string of hex digits of length len *)
   Fixpoint gen_hex (len : nat) : G Hexadecimal.uint :=
     match len with
@@ -1995,21 +1995,21 @@ Section ExpGenerators.
         r <- gen_hex n ;;
         oneof
            (ret (Hexadecimal.D0 r)) [
-            ret (Hexadecimal.D1 r) 
+            ret (Hexadecimal.D1 r)
           ; ret (Hexadecimal.D2 r)
-          ; ret (Hexadecimal.D3 r)                   
+          ; ret (Hexadecimal.D3 r)
           ; ret (Hexadecimal.D4 r)
-          ; ret (Hexadecimal.D5 r)                   
+          ; ret (Hexadecimal.D5 r)
           ; ret (Hexadecimal.D6 r)
-          ; ret (Hexadecimal.D7 r)                   
+          ; ret (Hexadecimal.D7 r)
           ; ret (Hexadecimal.D8 r)
-          ; ret (Hexadecimal.D9 r)                   
+          ; ret (Hexadecimal.D9 r)
           ; ret (Hexadecimal.Da r)
-          ; ret (Hexadecimal.Db r)                   
+          ; ret (Hexadecimal.Db r)
           ; ret (Hexadecimal.Dc r)
-          ; ret (Hexadecimal.Dd r)                   
+          ; ret (Hexadecimal.Dd r)
           ; ret (Hexadecimal.De r)
-          ; ret (Hexadecimal.Df r)                   
+          ; ret (Hexadecimal.Df r)
           ]
     end%nat.
 
@@ -2042,7 +2042,6 @@ Section ExpGenerators.
   Definition hex64_of_Z (z: Z) : Hexadecimal.uint :=
     hex_of_Z_fuel 16 z Hexadecimal.Nil.
 
-  (* SAZ: with the new representation of floating point syntax, these could probably be done with typeclasses *)
   Definition gen_float32_syntax : G float_syntax :=
     h <- gen_hex 8 ;;
     let z32 := BinInt.Z.of_hex_uint h in
@@ -2052,14 +2051,14 @@ Section ExpGenerators.
   Definition gen_double_syntax : G float_syntax :=
     h <- gen_hex 16 ;;
     ret (FS_hex FH_X h).
-  
+
   Definition gen_float32_exp : G (exp typ) :=
     ret EXP_Float <*> gen_float32_syntax.
 
   Definition gen_double_exp : G (exp typ) :=
     ret EXP_Float <*> gen_double_syntax.
 
-  
+
   (* TODO: make this more complex using metadata *)
   Definition gen_non_zero_exp_size (sz : nat) (t : typ) : GenLLVM (exp typ) :=
     match t with
@@ -2173,8 +2172,8 @@ Section ExpGenerators.
                         else mzero));;
               gen_exp_size' gen_global_of_typ gen_ident_of_typ 0%nat t
           (* Not generating these types for now *)
-          | TYPE_FP FP_float          => lift gen_float32_exp 
-          | TYPE_FP FP_double         => lift gen_double_exp 
+          | TYPE_FP FP_float          => lift gen_float32_exp
+          | TYPE_FP FP_double         => lift gen_double_exp
           | TYPE_FP _                 => failGen "gen_exp_size TYPE_FP"
           | TYPE_Label                => failGen "gen_exp_size TYPE_Label"
           | TYPE_Token                => failGen "gen_exp_size TYPE_Token"
@@ -2240,7 +2239,7 @@ Section ExpGenerators.
           | TYPE_FP FP_double      => [gen_fbinop_exp gen_global_of_typ gen_ident_of_typ (TYPE_FP FP_double)]
           | TYPE_FP _              => [failGen "gen_exp_size TYPE_FP list"]
           | TYPE_Metadata          => [failGen "gen_exp_size TYPE_Metadata list"]
-          | TYPE_Label             => [failGen "gen_exp_size TYPE_Label list"]                                       
+          | TYPE_Label             => [failGen "gen_exp_size TYPE_Label list"]
           | TYPE_Token             => [failGen "gen_exp_size TYPE_Token list"]
           | TYPE_X86_mmx           => [failGen "gen_exp_size TYPE_X86_mmx list"]
           | TYPE_Identified id     =>
@@ -2604,7 +2603,7 @@ Section InstrGenerators.
     | TYPE_Void => 0
     | TYPE_FP FP_half => 16
     | TYPE_FP FP_bfloat => 16
-    | TYPE_FP FP_float => 32                           
+    | TYPE_FP FP_float => 32
     | TYPE_FP FP_double => 64
     | TYPE_FP FP_x86_fp80 => 80
     | TYPE_FP FP_fp128 => 128

--- a/src/rocq/GenAST.v
+++ b/src/rocq/GenAST.v
@@ -10,25 +10,53 @@
 
     See vellvm-quickchick-overview.org in the root of the project for
     more details. *)
-Require Import Ceres.Ceres.
+
+From Vellvm.Syntax Require Import
+  CFG
+  TypeUtil
+  TypToDtyp
+  DynamicTypes.
+
+From Vellvm.Semantics Require Import
+  TopLevel.
+
+From Vellvm Require Import
+  LLVMAst
+  Utilities
+  AstLib
+  DynamicTypes
+  DList
+  IntMaps
+  Utils.Default.
+
+From Vellvm.QC Require Import
+  Utils
+  Generators
+  ECS
+  Lens
+  GenMetadata.
+
+
+Require Import Integers.
+
 
 From ExtLib.Structures Require Export
      Functor Applicative Monads Monoid.
 
 Require Import ExtLib.Data.Monads.StateMonad.
+Require Import ExtLib.Data.Monads.OptionMonad.
+Require Import ExtLib.Data.Monads.EitherMonad.
+Require Import ExtLib.Structures.Foldable.
 Require Import ExtLib.Structures.Monads.
 
 From Stdlib Require Import List.
 
 Import ListNotations.
 
-From Vellvm Require Import LLVMAst AstLib Syntax.CFG DynamicTypes Semantics.TopLevel Handlers DynamicValues.
-From GenLLVM Require Import Generators Utils.
-Require Import Integers.
-
-
 Import ListNotations.
 Import MonadNotation.
+Import FunctorNotation.
+Import LensNotations.
 Import ApplicativeNotation.
 
 From Stdlib Require Import
@@ -41,7 +69,8 @@ Set Warnings "-extraction-opaque-accessed,-extraction".
 From ExtLib.Structures Require Export
      Functor.
 Open Scope Z_scope.
-
+Open Scope lens.
+Open Scope string.
 
 (* Disable guard checking. This file is only used for generating test
     cases. Some of our generation functions terminate in non-trivial
@@ -49,66 +78,40 @@ Open Scope Z_scope.
     not used in proofs) it's not terribly important to prove that they
     actually terminate.  *)
 Unset Guard Checking.
-(** Difference lists *)
-Section DList.
-  Definition DList (A : Type) := list A -> list A.
 
-  Definition DList_to_list {A} (dl : DList A) : list A
-    := dl [].
-
-  Definition DList_append {A} (dl1 dl2 : DList A) : DList A
-    := fun xs => dl1 (dl2 xs).
-
-  Definition DList_singleton {A} (a : A) : DList A
-    := cons a.
-
-  Definition DList_cons {A} (a : A) (dl : DList A) : DList A
-    := DList_append (DList_singleton a) dl.
-
-  Definition DList_empty {A} : DList A
-    := fun xs => xs.
-
-  Definition DList_from_list {A} (l : list A) : DList A
-    := fold_right DList_cons DList_empty l.
-
-  Definition DList_map {A B} (f : A -> B) (dl : DList A) : DList B
-    := fold_right (fun a => DList_cons (f a)) (@DList_empty B) (DList_to_list dl).
-
-  #[global] Instance DList_Functor : Functor DList.
-  Proof.
-    split.
-    intros A B X X0.
-    eapply DList_map; eauto.
-  Defined.
-End DList.
+(* Controls whether or not we generate floats... The float generators
+often break with updates, so this may be convenient *)
+Definition enable_float_generation : bool := true.
 
 Section Helpers.
+  Definition l_is_empty {A : Type} (l : list A) : bool :=
+    match l with
+    | [] => true
+    | _ => false
+    end.
+
+
   Fixpoint is_sized_type_h (t : typ) : bool
     := match t with
        | TYPE_I sz => true
-       | TYPE_Iptr => true
+       | TYPE_IPTR => true
        | TYPE_Pointer (Some t) => is_sized_type_h t
-       | TYPE_Pointer None => false
+       | TYPE_Pointer None => true
        | TYPE_Void => false
        | TYPE_FP _ => true
+       | TYPE_Label => true
+       | TYPE_Token => true                          
        | TYPE_Metadata => true (* Not sure if this is right *)
        | TYPE_X86_mmx => true
        | TYPE_Array sz t => is_sized_type_h t
        | TYPE_Function ret args vararg => false
-       | TYPE_Struct fields => true
-       | TYPE_Packed_struct fields => true
+       | TYPE_Struct fields
+       | TYPE_Packed_struct fields =>
+           forallb is_sized_type_h fields
        | TYPE_Opaque => false
        | TYPE_Vector sz t => is_sized_type_h t
        | TYPE_Identified id => false
-       | TYPE_Labl => false
        end.
-
-  (* FIXME: This is broken *)
-  Definition normalize_type (typ_ctx : list (ident * typ)) (t : typ) := t.
-  
-  (* Only works correctly if the type is well formed *)
-  Definition is_sized_type (typ_ctx : list (ident * typ)) (t : typ) : bool
-    := is_sized_type_h (normalize_type typ_ctx t).
 
   Definition is_int_type_h (t : typ) : bool
     := match t with
@@ -132,17 +135,15 @@ Section Helpers.
   Definition is_function_pointer_h (t : typ) : bool
     := match t with
        | TYPE_Pointer (Some (TYPE_Function _ _ _)) => true
+       (* TODO: What about opaque pointers?  *)
        | _ => false
        end.
 
-  Definition is_function_pointer (typ_ctx : list (ident * typ)) (t : typ) : bool
-    := is_function_pointer_h (normalize_type typ_ctx t).
-
   (* TODO: incomplete. Should typecheck *)
-  Fixpoint well_formed_op (typ_ctx : list (ident * typ)) (op : exp typ) : bool :=
+  Definition well_formed_op (typ_ctx : list (ident * typ)) (op : exp typ) : bool :=
     match op with
     | OP_IBinop iop t v1 v2              => true
-    | OP_ICmp _ cmp t v1 v2                => true
+    | OP_ICmp ss cmp t v1 v2             => true
     | OP_FBinop fop fm t v1 v2           => true
     | OP_FCmp cmp t v1 v2                => true
     | OP_Conversion conv t_from v t_to   => true
@@ -156,6 +157,7 @@ Section Helpers.
     | OP_Freeze v                        => true
     | _                                  => false
     end.
+
   (*
   Fixpoint well_formed_instr (ctx : list (ident * typ)) (i : instr typ) : bool :=
     match i with
@@ -174,126 +176,199 @@ Section Helpers.
     end.
    *)
 
-  Definition int := (@bit_int 64).
-  
-  Definition genNatInt : G int
-    := fmap (fun n => repr (Z.of_nat n)) (arbitrary : G nat).
-
-  Definition genPosInt : G int
-    := fmap (fun n => repr (Z.of_nat (S n))) (arbitrary : G nat).
-
   Definition genPosZ : G Z
     :=
       n <- (arbitrary : G nat);;
-      ret (Z.of_nat n).
+      ret (Z.of_nat (S n)).
+  (* ret (Z.of_nat n). *)
+  (* TODO: ^This is the original code. Is this correct??? *)
 
   Definition genN : G N
     :=
       n <- (arbitrary : G nat);;
       ret (N.of_nat n).
+
+  Definition genPosN : G N
+    :=
+      n <- (arbitrary : G nat);;
+      ret (N.of_nat (S n)).
 End Helpers.
 
 Section GenerationState.
 
-  Definition type_context := list (ident * typ).
-  Definition var_context := list (ident * typ).
-  Definition ptr_to_int_context := list (typ * ident * typ).
-  Definition all_var_contexts := (var_context * ptr_to_int_context)%type.
+  Definition VariableMetadata := Metadata FieldOf.
+  Definition VariableMetadataMap := IM.Raw.t VariableMetadata.
+  Definition type_context := VariableMetadataMap.
+  Definition var_context := VariableMetadataMap.
+  Definition ptr_to_int_context := VariableMetadataMap.
+  Definition all_local_var_contexts := (var_context * ptr_to_int_context)%type.
+  Definition all_var_contexts := (var_context * var_context * ptr_to_int_context)%type.
+  Definition ContextMetadata s := Metadata s.
 
-  Record GenState :=
+  Record GenState s :=
     mkGenState
     { num_void : N
     ; num_raw  : N
     ; num_global : N
     ; num_blocks : N
-    (* Types of values *)
-    ; gen_ctx : var_context
-    (* Type aliases *)
-    ; gen_typ_ctx : type_context
-    ; gen_ptrtoint_ctx : ptr_to_int_context
+    ; context : ContextMetadata s
+    ; global_memo : list (global typ)
+    ; debug_stack : list string
     }.
 
-  Definition init_GenState : GenState
-    := {| num_void   := 0
-        ; num_raw    := 0
-        ; num_global := 0
-        ; num_blocks := 0
-        ; gen_ctx    := []
-        ; gen_typ_ctx    := []
-        ; gen_ptrtoint_ctx := []
-       |}.
+  Instance Default_GenState {s} : Default (GenState s)
+    :=
+    { def := {| num_void   := 0
+             ; num_raw    := 0
+             ; num_global := 0
+             ; num_blocks := 0
+             ; context := def
+             ; global_memo := []
+             ; debug_stack := []
+             |}
+    }.
 
-  Definition increment_raw (gs : GenState) : GenState
-    := {| num_void    := gs.(num_void)
-        ; num_raw     := N.succ gs.(num_raw)
-        ; num_global  := gs.(num_global)
-        ; num_blocks  := gs.(num_blocks)
-        ; gen_ctx     := gs.(gen_ctx)
-        ; gen_typ_ctx := gs.(gen_typ_ctx)
-        ; gen_ptrtoint_ctx := gs.(gen_ptrtoint_ctx)
-       |}.
+  Definition num_void' {s} : Lens' (GenState s) N.
+    red.
+    intros f F afa gs.
+    refine ((fun x => _) <$> afa (_ gs)); try typeclasses eauto.
+    - apply mkGenState;
+        [ apply x
+        | apply (num_raw s)
+        | apply (num_global s)
+        | apply (num_blocks s)
+        | apply (context s)
+        | apply (global_memo s)
+        | apply (debug_stack s)
+        ]; apply gs.
+    - apply num_void.
+  Defined.
 
-  Definition increment_global (gs : GenState) : GenState
-    := {| num_void    := gs.(num_void)
-        ; num_raw     := gs.(num_raw)
-        ; num_global  := N.succ gs.(num_global)
-        ; num_blocks  := gs.(num_blocks)
-        ; gen_ctx     := gs.(gen_ctx)
-        ; gen_typ_ctx := gs.(gen_typ_ctx)
-        ; gen_ptrtoint_ctx := gs.(gen_ptrtoint_ctx)
-       |}.
+  Definition num_raw' {s} : Lens' (GenState s) N.
+    red.
+    intros f F afa gs.
+    refine ((fun x => _) <$> afa (_ gs)); try typeclasses eauto.
+    - apply mkGenState;
+        [ apply (num_void s)
+        | apply x
+        | apply (num_global s)
+        | apply (num_blocks s)
+        | apply (context s)
+        | apply (global_memo s)
+        | apply (debug_stack s)
+        ]; apply gs.
+    - apply num_raw.
+  Defined.
 
-  Definition increment_void (gs : GenState) : GenState
-    := {| num_void    := N.succ gs.(num_void)
-        ; num_raw     := gs.(num_raw)
-        ; num_global  := gs.(num_global)
-        ; num_blocks  := gs.(num_blocks)
-        ; gen_ctx     := gs.(gen_ctx)
-        ; gen_typ_ctx := gs.(gen_typ_ctx)
-        ; gen_ptrtoint_ctx := gs.(gen_ptrtoint_ctx)
-       |}.
+  Definition num_global' {s} : Lens' (GenState s) N.
+    red.
+    intros f F afa gs.
+    refine ((fun x => _) <$> afa (_ gs)); try typeclasses eauto.
+    - apply mkGenState;
+        [ apply (num_void s)
+        | apply (num_raw s)
+        | apply x
+        | apply (num_blocks s)
+        | apply (context s)
+        | apply (global_memo s)
+        | apply (debug_stack s)
+        ]; apply gs.
+    - apply num_global.
+  Defined.
 
-  Definition increment_blocks (gs : GenState) : GenState
-    := {| num_void    := gs.(num_void)
-        ; num_raw     := gs.(num_raw)
-        ; num_global  := gs.(num_global)
-        ; num_blocks  := N.succ gs.(num_blocks)
-        ; gen_ctx     := gs.(gen_ctx)
-        ; gen_typ_ctx := gs.(gen_typ_ctx)
-        ; gen_ptrtoint_ctx := gs.(gen_ptrtoint_ctx)
-       |}.
+  Definition num_blocks' {s} : Lens' (GenState s) N.
+    red.
+    intros f F afa gs.
+    refine ((fun x => _) <$> afa (_ gs)); try typeclasses eauto.
+    - apply mkGenState;
+        [ apply (num_void s)
+        | apply (num_raw s)
+        | apply (num_global s)
+        | apply x
+        | apply (context s)
+        | apply (global_memo s)
+        | apply (debug_stack s)
+        ]; apply gs.
+    - apply num_blocks.
+  Defined.
 
-  Definition replace_ctx (ctx : list (ident * typ)) (gs : GenState) : GenState
-    := {| num_void    := gs.(num_void)
-        ; num_raw     := gs.(num_raw)
-        ; num_global  := gs.(num_global)
-        ; num_blocks  := gs.(num_blocks)
-        ; gen_ctx     := ctx
-        ; gen_typ_ctx := gs.(gen_typ_ctx)
-        ; gen_ptrtoint_ctx := gs.(gen_ptrtoint_ctx)
-       |}.
+  Definition context' {s} : Lens' (GenState s) (ContextMetadata s).
+    red.
+    intros f F afa gs.
+    refine ((fun x => _) <$> afa (_ gs)); try typeclasses eauto.
+    - apply mkGenState;
+        [ apply (num_void s)
+        | apply (num_raw s)
+        | apply (num_global s)
+        | apply (num_blocks s)
+        | apply x
+        | apply (global_memo s)
+        | apply (debug_stack s)
+        ]; apply gs.
+    - apply context.
+  Defined.
 
-  Definition replace_typ_ctx (typ_ctx : list (ident * typ)) (gs : GenState) : GenState
-    := {| num_void    := gs.(num_void)
-        ; num_raw     := gs.(num_raw)
-        ; num_global  := gs.(num_global)
-        ; num_blocks  := gs.(num_blocks)
-        ; gen_ctx     := gs.(gen_ctx)
-        ; gen_typ_ctx := typ_ctx
-        ; gen_ptrtoint_ctx := gs.(gen_ptrtoint_ctx)
-       |}.
+  Definition global_memo' {s} : Lens' (GenState s) (list (global typ)).
+    red.
+    intros f F afa gs.
+    refine ((fun x => _) <$> afa (_ gs)); try typeclasses eauto.
+    - apply mkGenState;
+        [ apply (num_void s)
+        | apply (num_raw s)
+        | apply (num_global s)
+        | apply (num_blocks s)
+        | apply (context s)
+        | apply x
+        | apply (debug_stack s)
+        ]; apply gs.
+    - apply global_memo.
+  Defined.
 
-  Definition replace_ptrtoint_ctx (ptrtoint_ctx : list (typ * ident * typ)) (gs: GenState) : GenState
-    := {| num_void    := gs.(num_void)
-        ; num_raw     := gs.(num_raw)
-        ; num_global  := gs.(num_global)
-        ; num_blocks  := gs.(num_blocks)
-        ; gen_ctx     := gs.(gen_ctx)
-        ; gen_typ_ctx := gs.(gen_typ_ctx)
-        ; gen_ptrtoint_ctx := ptrtoint_ctx
-       |}.
+  Definition debug_stack' {s} : Lens' (GenState s) (list string).
+    red.
+    intros f F afa gs.
+    refine ((fun x => _) <$> afa (_ gs)); try typeclasses eauto.
+    - apply mkGenState;
+        [ apply (num_void s)
+        | apply (num_raw s)
+        | apply (num_global s)
+        | apply (num_blocks s)
+        | apply (context s)
+        | apply (global_memo s)
+        | apply x
+        ]; apply gs.
+    - apply debug_stack.
+  Defined.
 
-  Definition GenLLVM := stateT GenState G.
+
+  Definition increment_raw {s} (gs : GenState s) : GenState s
+    := gs & num_raw' %~ N.succ.
+
+  Definition increment_global {s} (gs : GenState s) : GenState s
+    := gs & num_global' %~ N.succ.
+
+  Definition increment_void {s} (gs : GenState s) : GenState s
+    := gs & num_void' %~ N.succ.
+
+  Definition increment_blocks {s} (gs : GenState s) : GenState s
+    := gs & num_blocks' %~ N.succ.
+
+  Definition replace_local_ctx {s} (ctx : Component s Field unit) (gs : GenState s) : GenState s
+    := gs & (context' .@  is_local') .~ ctx.
+
+  Definition replace_global_ctx {s} (ctx : Component s Field unit) (gs : GenState s) : GenState s
+    := gs & (context' .@  is_global') .~ ctx.
+
+  Definition replace_typ_ctx {s} (typ_ctx : Component s Field typ) (gs : GenState s) : GenState s
+    := gs & (context' .@ type_alias') .~ typ_ctx.
+
+  Definition replace_ptrtoint_ctx {s} (ptrtoint_ctx : Component s Field Ent) (gs: GenState s) : GenState s
+    := gs & (context' .@ from_pointer') .~ ptrtoint_ctx.
+
+  Definition replace_global_memo {s} (global_memo : list (global typ)) (gs : GenState s) : GenState s
+    := gs & global_memo' .~ global_memo.
+
+  Definition GenLLVM := (eitherT string (SystemT GenState G)).
 
   (* Need this because extlib doesn't declare this instance as global :|. *)
   #[global] Instance monad_stateT {s m} `{Monad m} : Monad (stateT s m).
@@ -302,161 +377,280 @@ Section GenerationState.
       typeclasses eauto.
   Defined.
 
-  Definition get_raw (gs : GenState) : N
-    := gs.(num_raw).
+  #[global] Instance MonadState_GenLLVM : MonadState (SystemState GenState G) GenLLVM.
+  unfold SystemT.
+  try typeclasses eauto.
+  Defined.
 
-  Definition get_global (gs : GenState) : N
-    := gs.(num_global).
+  Definition gen_context' : Lens' (SystemState GenState G) (ContextMetadata _)
+    := (metadata .@ context').
 
-  Definition get_void (gs : GenState) : N
-    := gs.(num_void).
+  Definition get_raw {s} (gs : GenState s) : N
+    := gs .^ num_raw'.
 
-  Definition get_blocks (gs : GenState) : N
-    := gs.(num_blocks).
+  Definition get_global {s} (gs : GenState s) : N
+    := gs .^ num_global'.
+
+  Definition get_void {s} (gs : GenState s) : N
+    := gs .^ num_void'.
+
+  Definition get_blocks {s} (gs : GenState s) : N
+    := gs .^ num_blocks'.
+
+  Definition new_id {ID} (id_lens : forall {s : StorageType}, Lens' (GenState s) N) (id_gen : N -> ID) : GenLLVM ID
+    := n <- use (metadata .@ num_raw');;
+       metadata .@ num_raw' %= N.succ;;
+       ret (id_gen n).
+
+  Definition new_local_id : GenLLVM local_id
+    := new_id (@num_raw') (fun n => Name ("v" ++ show n)).
+
+  Definition new_global_id : GenLLVM global_id
+    := new_id (@num_raw') (fun n => Name ("g" ++ show n)).
+
+  Definition new_void_id : GenLLVM instr_id
+    := new_id (@num_void') (fun n => IVoid (Z.of_N n)).
+
+  Definition new_block_id : GenLLVM block_id
+    := new_id (@num_blocks') (fun n => Name ("b" ++ show n)).
+
+  (* #[global] Instance STGST : Monad (stateT GenState G). *)
+  (* apply Monad_stateT. *)
+  (* typeclasses eauto. *)
+  (* Defined. *)
 
   #[global] Instance MGEN : Monad GenLLVM.
   unfold GenLLVM.
-  apply Monad_stateT.
+  apply Monad_eitherT.
   typeclasses eauto.
   Defined.
 
-  Definition new_raw_id : GenLLVM raw_id
-    := n <- gets get_raw;;
-       modify increment_raw;;
-       ret (Name ("v" ++ show n)).
+  (* GC: For following, I will leave pieces defined in another way so I can learn more about how to use monad *)
+  (* Definition lift_GenLLVM {A} (g : G A) : GenLLVM A := *)
+  (* mkEitherT (mkStateT (fun stack => mkStateT (fun st => a <- g;; ret (inr a, stack, st)))). *)
 
-  Definition new_global_id : GenLLVM raw_id
-    := n <- gets get_global;;
-       modify increment_global;;
-       ret (Name ("g" ++ show n)).
+  Definition lift_GenLLVM {A} (g : G A) : GenLLVM A.
+    unfold GenLLVM.
+    apply mkEitherT.
+    apply mkStateT.
+    (* intros. *)
+    refine (fun st => _).
+    refine (a <- g ;; ret _).
+    exact (inr a, st).
+  Defined.
 
-  Definition new_void_id : GenLLVM instr_id
-    := n <- gets get_void;;
-       modify increment_void;;
-       ret (IVoid (Z.of_N n)).
+  #[global] Instance MGENT: MonadT GenLLVM G.
+  unfold GenLLVM.
+  constructor.
+  exact @lift_GenLLVM.
+  Defined.
 
-  Definition new_block_id : GenLLVM block_id
-    := n <- gets get_blocks;;
-       modify increment_blocks;;
-       ret (Name ("b" ++ show n)).
+  Definition lift_system_GenLLVM {A} (system : SystemT GenState G A) : GenLLVM A.
+    unfold GenLLVM.
+    apply mkEitherT.
+    apply (fmap ret system).
+  Defined.
+
+  #[global] Instance MGENTSYSTEM: MonadT GenLLVM (SystemT GenState G).
+  unfold GenLLVM.
+  constructor.
+  exact @lift_system_GenLLVM.
+  Defined.
+
+  (* SAZ:
+     [failGen] was the one piece of the backtracking variant of QuickChick we
+     needed.
+   *)
+  (* Definition failGen {A:Type} (s:string) : GenLLVM A := *)
+  (* mkEitherT (mkStateT (fun stack => ret (inl s, stack))). *)
+
+  Definition failGen {A:Type} (s:string) : GenLLVM A.
+    apply mkEitherT.
+    apply mkStateT.
+    refine (fun stack => _).
+    exact (ret (inl (s), stack)).
+  Defined.
+
+  Definition annotate {A:Type} (s:string) (g : GenLLVM A) : GenLLVM A
+    := old_stack <- use (metadata .@ debug_stack');;
+       metadata .@ debug_stack' %= (fun stack => s :: stack);;
+       a <- g;;
+       metadata .@ debug_stack' .= old_stack;;
+       ret a.
+
+  Definition annotate_debug (s : string) : GenLLVM unit :=
+    annotate s (ret tt).
+
+  Definition dup_string_wrt_nat (s : string) (n : nat) :=
+    let fix dup_string_wrt_nat_tail_recur (acc : string) (n : nat):=
+      match n with
+      | 0%nat => acc
+      | S z => dup_string_wrt_nat_tail_recur (s ++ acc)%string z
+      end in dup_string_wrt_nat_tail_recur "" n.
+
+  #[global] Instance MetadataStore_GenState : @MetadataStore G Metadata (SystemState GenState G).
+  split.
+  apply gen_context'.
+  Defined.
+
+  Definition contextFromMap {a} (m : IM.Raw.t a) : GenLLVM var_context
+    := IM.Raw.fold
+         (fun (k : Z) _ (acc : GenLLVM var_context) =>
+            e <- lift_system_GenLLVM (getEntity (mkEnt k));;
+            ctx <- acc;;
+            ret (IM.Raw.add k e ctx)
+         ) m (ret (IM.Raw.empty _)).
+
+  Definition get_local_ctx : GenLLVM var_context
+    := locals <- use (gen_context' .@ is_local');;
+       contextFromMap locals.
+
+  Definition get_global_ctx : GenLLVM var_context
+    := globals <- use (gen_context' .@ is_global');;
+       contextFromMap globals.
+
+  Definition merge_var_context (c1 : var_context) (c2 : var_context) : var_context
+    := IM.Raw.merge c1 c2.
 
   Definition get_ctx : GenLLVM var_context
-    := gets (fun gs => gs.(gen_ctx)).
+    := locals <- use (gen_context' .@ is_local');;
+       globals <- use (gen_context' .@ is_global');;
+       contextFromMap (IM.Raw.merge globals locals).
 
   Definition get_typ_ctx : GenLLVM type_context
-    := gets (fun gs => gs.(gen_typ_ctx)).
+    := types <- use (gen_context' .@ type_alias');;
+       contextFromMap types.
 
   Definition get_ptrtoint_ctx : GenLLVM ptr_to_int_context
-    := gets (fun gs => gs.(gen_ptrtoint_ctx)).
+    := ptois <- use (gen_context' .@ from_pointer');;
+       contextFromMap ptois.
 
   (* Get all variable contexts that might need to be saved *)
   Definition get_variable_ctxs : GenLLVM all_var_contexts
-    := ctx <- get_ctx;;
+    := local_ctx <- get_local_ctx;;
+       global_ctx <- get_global_ctx;;
        ptoi_ctx <- get_ptrtoint_ctx;;
-       ret (ctx, ptoi_ctx).
+       ret (local_ctx, global_ctx, ptoi_ctx).
 
-  Definition set_ctx (ctx : var_context) : GenLLVM unit
-    := modify (replace_ctx ctx);;
-       ret tt.
+  Definition get_global_memo : GenLLVM (list (global typ))
+    := use (metadata .@ global_memo').
+
+  Definition set_local_ctx (ctx : var_context) : GenLLVM unit
+    := lift (setEntities ctx).
+
+  Definition set_global_ctx (ctx : var_context) : GenLLVM unit
+    := lift (setEntities ctx).
 
   Definition set_ptrtoint_ctx (ptoi_ctx : ptr_to_int_context) : GenLLVM unit
-    := modify (replace_ptrtoint_ctx ptoi_ctx);;
+    := lift (setEntities ptoi_ctx).
+
+  Definition set_global_memo (memo : list (global typ)) : GenLLVM unit
+    := (metadata .@ global_memo') .= memo;;
+       ret tt.
+
+  Definition add_to_global_memo (x : (global typ)) : GenLLVM unit
+    := (metadata .@ global_memo') %= (fun memo => x :: memo);;
        ret tt.
 
   Definition restore_variable_ctxs (ctxs : all_var_contexts) : GenLLVM unit
     := match ctxs with
-       | (ctx, ptoi_ctx) =>
-           set_ctx ctx;;
+       | (local_ctx, global_ctx, ptoi_ctx) =>
+           set_local_ctx local_ctx;;
+           set_global_ctx global_ctx;;
            set_ptrtoint_ctx ptoi_ctx
        end.
 
-  (* TODO: Do we need this? *)
-  Definition filter_global_from_variable_ctxs (ctxs : all_var_contexts) : all_var_contexts
-    := let is_global_id (id: ident) :=
-         match id with
-         | ID_Global _ => true
-         | ID_Local _ => false
-         end in
-       match ctxs with
-       | (ctx, ptoi_ctx) =>
-           let globals_in_ctx := filter (fun '(id, _) => is_global_id id) ctx in
-           let globals_in_ptoi_ctx := filter (fun '(_, id, _) => is_global_id id) ptoi_ctx in
-           (globals_in_ctx, globals_in_ptoi_ctx)
+  Definition restore_local_variable_ctxs (ctxs : all_local_var_contexts) : GenLLVM unit
+    := match ctxs with
+       | (local_ctx, ptoi_ctx) =>
+           set_local_ctx local_ctx;;
+           set_ptrtoint_ctx ptoi_ctx
        end.
 
-  Definition add_to_ctx (x : (ident * typ)) : GenLLVM unit
-    := ctx <- get_ctx;;
-       let new_ctx := x :: ctx in
-       modify (replace_ctx new_ctx);;
-       ret tt.
+  Definition append_ctx (vars :var_context) : GenLLVM unit
+    := lift (setEntities vars).
 
-  Definition add_to_typ_ctx (x : (ident * typ)) : GenLLVM unit
-    := ctx <- get_typ_ctx;;
-       let new_ctx := x :: ctx in
-       modify (replace_typ_ctx new_ctx);;
-       ret tt.
+  (* This is very aggressive and will reset entities / entity counter *)
+  Definition backtrackMetadata {A} (g : GenLLVM A) : GenLLVM A
+    := m <- use gen_context';;
+       a <- g;;
+       gen_context' .= m;;
+       ret a.
 
-  Definition add_to_ptrtoint_ctx (x : (typ * ident * typ)) : GenLLVM unit
-    := ctx <- get_ptrtoint_ctx;;
-       let new_ctx := x :: ctx in
-       modify (replace_ptrtoint_ctx new_ctx);;
-       ret tt.
+  Definition reset_local_ctx : GenLLVM unit
+    := locals <- use (gen_context' .@ is_local');;
+       lift (deleteEntities locals).
 
-  Definition append_to_ctx (vars : list (ident * typ)) : GenLLVM unit
-    := ctx <- get_ctx;;
-       let new_ctx := (vars ++ ctx)%list in
-       modify (replace_ctx new_ctx);;
-       ret tt.
-
-  Definition append_to_typ_ctx (aliases : list (ident * typ)) : GenLLVM unit
-    := ctx <- get_typ_ctx;;
-       let new_ctx := (aliases ++ ctx)%list in
-       modify (replace_typ_ctx new_ctx);;
-       ret tt.
-
-  Definition append_to_ptrtoint_ctx (aliases : list (typ * ident * typ)) : GenLLVM unit
-    := ctx <- get_ptrtoint_ctx;;
-       let new_ctx := (aliases ++ ctx)%list in
-       modify (replace_ptrtoint_ctx new_ctx);;
-       ret tt.
+  Definition reset_global_ctx : GenLLVM unit
+    := globals <- use (gen_context' .@ is_global');;
+       lift (deleteEntities globals).
 
   Definition reset_ctx : GenLLVM unit
-    := modify (replace_ctx []);; ret tt.
+    := reset_local_ctx;;
+       reset_global_ctx.
 
   Definition reset_typ_ctx : GenLLVM unit
-    := modify (replace_typ_ctx []);; ret tt.
+    := types <- use (gen_context' .@ type_alias');;
+       lift (deleteEntities types).
 
   Definition reset_ptrtoint_ctx : GenLLVM unit
-    := modify (replace_ptrtoint_ctx []);; ret tt.
+    := ptrs <- use (gen_context' .@ from_pointer');;
+       lift (deleteEntities ptrs).
+
+  Definition reset_global_memo : GenLLVM unit
+    := metadata .@ global_memo' .= def;;
+       ret tt.
+
+  Definition hide_local_ctx {A} (g : GenLLVM A) : GenLLVM A
+    := saved_local_ctx <- get_local_ctx;;
+       reset_local_ctx;;
+       a <- g;;
+       set_local_ctx saved_local_ctx;;
+       ret a.
+
+  Definition hide_global_ctx {A} (g : GenLLVM A) : GenLLVM A
+    := saved_global_ctx <- get_global_ctx;;
+       reset_global_ctx;;
+       a <- g;;
+       set_global_ctx saved_global_ctx;;
+       ret a.
 
   Definition hide_ctx {A} (g: GenLLVM A) : GenLLVM A
-    := saved_ctx <- get_ctx;;
-       reset_ctx;;
-       a <- g;;
-       append_to_ctx saved_ctx;;
-       ret a.
+    := hide_global_ctx (hide_local_ctx g).
 
   Definition hide_ptrtoint_ctx {A} (g: GenLLVM A) : GenLLVM A
     := saved_ctx <- get_ptrtoint_ctx;;
        reset_ptrtoint_ctx;;
        a <- g;;
-       append_to_ptrtoint_ctx saved_ctx;;
+       append_ctx saved_ctx;;
        ret a.
 
   Definition hide_variable_ctxs {A} (g: GenLLVM A) : GenLLVM A
     := hide_ctx (hide_ptrtoint_ctx g).
 
   (** Restore context after running a generator. *)
-  Definition backtrack_ctx {A} (g: GenLLVM A) : GenLLVM A
-    := saved_ctx <- get_ctx;;
+  Definition backtrack_local_ctx {A} (g: GenLLVM A) : GenLLVM A
+    := saved_local_ctx <- get_local_ctx;;
        a <- g;;
-       set_ctx saved_ctx;;
+       reset_local_ctx;;
+       set_local_ctx saved_local_ctx;;
        ret a.
+
+  Definition backtrack_global_ctx {A} (g: GenLLVM A) : GenLLVM A
+    := saved_global_ctx <- get_global_ctx;;
+       a <- g;;
+       reset_global_ctx;;
+       set_global_ctx saved_global_ctx;;
+       ret a.
+
+  Definition backtrack_ctx {A} (g : GenLLVM A) : GenLLVM A
+    := backtrack_global_ctx (backtrack_local_ctx g).
 
   (** Restore ptrtoint context after running a generator. *)
   Definition backtrack_ptrtoint_ctx {A} (g: GenLLVM A) : GenLLVM A
     := saved_ctx <- get_ptrtoint_ctx;;
        a <- g;;
+       reset_global_ctx;;
        set_ptrtoint_ctx saved_ctx;;
        ret a.
 
@@ -464,44 +658,216 @@ Section GenerationState.
   Definition backtrack_variable_ctxs {A} (g: GenLLVM A) : GenLLVM A
     := backtrack_ctx (backtrack_ptrtoint_ctx g).
 
+  (* Elems implemented with reservoir sampling *)
+  Definition elems_res {A} (def : G A) (l : list A) : G A
+    := fst
+         (fold_left
+            (fun '(gacc, k) a =>
+               let gen' :=
+                 swap <- fmap (N.eqb 0) (choose (0%N, k));;
+                 if swap
+                 then (* swap *)
+                   ret a
+                 else (* No swap *)
+                   gacc
+               in (gen', (k+1)%N))
+            l (def, 0%N)).
+
   Definition oneOf_LLVM {A} (gs : list (GenLLVM A)) : GenLLVM A
-    := n <- lift (choose (0, List.length gs - 1)%nat);;
-       nth n gs (lift failGen).
+    := fst
+         (fold_left
+            (fun '(gacc, k) a =>
+               let gen' :=
+                 swap <- lift (fmap (N.eqb 0) (choose (0%N, k)));;
+                 if swap
+                 then (* swap *)
+                   a
+                 else (* No swap *)
+                   gacc
+               in (gen', (k+1)%N))
+            gs (failGen "oneOf_LLVM", 0%N)).
+
+  Definition oneOf_res {A} (def : G A) (gs : list (G A)) : G A
+    := fst
+         (fold_left
+            (fun '(gacc, k) a =>
+               let gen' :=
+                 swap <- fmap (N.eqb 0) (choose (0%N, k));;
+                 if swap
+                 then (* swap *)
+                   a
+                 else (* No swap *)
+                   gacc
+               in (gen', (k+1)%N))
+            gs (def, 0%N)).
+
+  Definition freq_res {A} (def : G A) (gs : list (N * G A)) : G A
+    := fst
+         (fold_left
+            (fun '(gacc, k) '(fk, a) =>
+               let k' := (k + fk)%N in
+               let gen' :=
+                 swap <- fmap (fun x => N.leb x fk) (choose (0%N, k'));;
+                 if swap
+                 then (* swap *)
+                   a
+                 else (* No swap *)
+                   gacc
+               in (gen', k'))
+            gs (def, 0%N)).
+
+  Definition freq_LLVM_N {A} (gs : list (N * GenLLVM A)) : GenLLVM A
+    := fst
+         (fold_left
+            (fun '(gacc, k) '(fk, a) =>
+               let k' := (k + fk)%N in
+               let gen' :=
+                 swap <- lift (fmap (fun x => N.leb x fk) (choose (0%N, k')));;
+                 if swap
+                 then (* swap *)
+                   a
+                 else (* No swap *)
+                   gacc
+               in (gen', k'))
+            gs (failGen "freq_LLVM_N", 0%N)).
 
   Definition freq_LLVM {A} (gs : list (nat * GenLLVM A)) : GenLLVM A
-    := mkStateT
-         (fun st => freq_ failGen (fmap (fun '(n, g) => (n, runStateT g st)) gs)).
+    :=
+    (* ctx <- get_ctx;; *)
+    (* let is_empty := l_is_empty ctx in *)
+    fst
+         (fold_left
+            (fun '(gacc, k) '(fk, a) =>
+               let fkn := N.of_nat fk in
+               let k' := (k + fkn)%N in
+               let gen' :=
+                 swap <- lift (fmap (fun x => N.leb x fkn) (choose (0%N, k')));;
+                 if swap
+                 then (* swap *)
+                   a
+                 else (* No swap *)
+                   gacc
+               in (gen', k'))
+            gs (failGen ("freq_LLVM" (* ++ newline ++ if (is_empty) then "Current context is empty" else "Current context: " ++ show ctx *)), 0%N)).
+
+  (* SAZ: Where do we need this? *)
+  (*
+  Definition freq_LLVM' {A} (gs : list (nat * GenLLVM A)) : GenLLVM A
+    :=
+        mkStateT
+          (fun st => freq_ failGen (fmap (fun '(n, g) => (n, runStateT g st)) gs)).
+   *)
+
 
   Definition thunkGen_LLVM {A} (thunk : unit -> GenLLVM A) : GenLLVM A
     := u <- ret tt;;
        thunk tt.
 
   Definition oneOf_LLVM_thunked {A} (gs : list (unit -> GenLLVM A)) : GenLLVM A
+    := thunkGen_LLVM
+         (fst
+            (fold_left
+               (fun '(gacc, k) a =>
+                  let gen' := fun x =>
+                    swap <- lift (fmap (N.eqb 0) (choose (0%N, k)));;
+                    if swap
+                    then (* swap *)
+                      a x
+                    else (* No swap *)
+                      gacc x
+                  in (gen', (k+1)%N))
+               gs (fun _ => failGen "oneOF_LLVM_thunked", 0%N))).
+
+  Definition oneOf_LLVM_thunked' {A} (gs : list (unit -> GenLLVM A)) : GenLLVM A
     := n <- lift (choose (0, List.length gs - 1)%nat);;
-       thunkGen_LLVM (nth n gs (fun _ => lift failGen)).
+       thunkGen_LLVM (nth n gs (fun _ => failGen "oneOf_LLVM_thunked'")).
+
+  Definition freq_LLVM_thunked_N {A} (gs : list (N * (unit -> GenLLVM A))) : GenLLVM A
+    := thunkGen_LLVM
+         (fst
+            (fold_left
+               (fun '(gacc, k) '(fk, a) =>
+                  let k' := (k + fk)%N in
+                  let gen' := fun x =>
+                    swap <- lift (fmap (fun x => N.leb x fk) (choose (0%N, k')));;
+                    if swap
+                    then (* swap *)
+                      a x
+                    else (* No swap *)
+                      gacc x
+                  in (gen', k'))
+               gs (fun _ => failGen "freq_LLVM_thunked_N'", 0%N))).
 
   Definition freq_LLVM_thunked {A} (gs : list (nat * (unit -> GenLLVM A))) : GenLLVM A
+    := thunkGen_LLVM
+         (fst
+            (fold_left
+               (fun '(gacc, k) '(fk, a) =>
+                  let fkn := N.of_nat fk in
+                  let k' := (k + fkn)%N in
+                  let gen' := fun x =>
+                    swap <- lift (fmap (fun x => N.leb x fkn) (choose (0%N, k')));;
+                    if swap
+                    then (* swap *)
+                      a x
+                    else (* No swap *)
+                      gacc x
+                  in (gen', k'))
+               gs (fun _ => failGen "freq_LLVM_thunked", 0%N))).
+
+  (* SAZ: do we need this? *)
+  (*
+  Definition freq_LLVM_thunked' {A} (gs : list (nat * (unit -> GenLLVM A))) : GenLLVM A
     := mkStateT
          (fun st => freq_ failGen (fmap (fun '(n, g) => (n, runStateT (thunkGen_LLVM g) st)) gs)).
+   *)
 
-  Definition elems_LLVM {A : Type} (l: list A) : GenLLVM A (* TODO: Need a more efficient way*)
-    := n <- lift (choose (0, List.length l - 1)%nat);;
-       nth n (map ret l) (lift failGen).
+  Definition elems_LLVM {A : Type} (l: list A) : GenLLVM A
+    := fst
+         (fold_left
+            (fun '(gacc, k) a =>
+               let gen' :=
+                 swap <- lift (fmap (N.eqb 0) (choose (0%N, k)));;
+                 if swap
+                 then (* swap *)
+                   ret a
+                 else (* No swap *)
+                   gacc
+               in (gen', (k+1)%N))
+            l (failGen "elems_LLVM", 0%N)).
 
   Definition vectorOf_LLVM {A : Type} (k : nat) (g : GenLLVM A)
     : GenLLVM (list A) :=
-    fold_right (fun m m' =>
-                  x <- m;;
-                  xs <- m';;
-                  ret (x :: xs)) (ret []) (repeat g k).
+    fold_left (fun m' m =>
+                 x <- m;;
+                 xs <- m';;
+                 ret (x :: xs)) (repeat g k) (ret []).
 
-  Definition sized_LLVM {A : Type} (gn : nat -> GenLLVM A) : GenLLVM A
-    := mkStateT
-         (fun st => sized (fun n => runStateT (gn n) st)).
+  Definition sized_LLVM {A : Type} (gn : nat -> GenLLVM A) : GenLLVM A.
+    apply mkEitherT.
+    apply mkStateT.
+    refine (fun st => sized _).
+    refine (fun n => _).
+    refine (let opt := unEitherT (gn n) in _).
+    refine (let ann := runStateT opt st in ann).
+    Defined.
 
-  Definition resize_LLVM {A : Type} (sz : nat) (g : GenLLVM A) : GenLLVM A
-    := mkStateT
-         (fun st => resize sz (runStateT g st)).
+  (* Definition sized_LLVM {A : Type} (gn : nat -> GenLLVM A) : GenLLVM A *)
+  (*   := mkEitherT (mkStateT *)
+  (*                   (fun st => sized (fun n => runStateT (unEitherT (gn n)) st))). *)
+
+  Definition resize_LLVM {A : Type} (sz : nat) (g : GenLLVM A) : GenLLVM A.
+    apply mkEitherT.
+    apply mkStateT.
+    refine (fun st => _).
+    refine (let opt := unEitherT g in _).
+    refine (let ans := runStateT opt st in _).
+    refine (resize sz ans).
+    Defined.
+
+  (* Definition resize_LLVM {A : Type} (sz : nat) (g : GenLLVM A) : GenLLVM A *)
+  (*   := mkEitherT (mkStateT *)
+  (*                   (fun st => resize sz (runStateT (unEitherT g) st))). *)
 
   Definition listOf_LLVM {A : Type} (g : GenLLVM A) : GenLLVM (list A) :=
     sized_LLVM (fun n =>
@@ -514,318 +880,767 @@ Section GenerationState.
                      k <- lift (choose (1, n)%nat);;
                      vectorOf_LLVM k g).
 
-  Definition run_GenLLVM {A} (g : GenLLVM A) : G A
-    := fmap fst (runStateT g init_GenState).
-
-  Definition lift_GenLLVM {A} (g : G A) : GenLLVM A
-    := mkStateT (fun st => a <- g;; ret (a, st)).
+  Definition run_GenLLVM {A} (g: GenLLVM A) : G (string + A) :=
+    let ran := runStateT (unEitherT g) def in
+    '(err_a,st) <- ran;;
+    let stack := st .^ metadata .@ debug_stack' in
+    let debug : string := fold_right (fun d1 drest => (d1 ++ newline ++ drest)%string) "" (rev stack) in
+    let flushed_err :=
+      match err_a with
+      | inl err_str => inl (err_str ++ newline ++ "DEBUG SECTION: " ++ newline ++ debug)%string
+      | inr _ => err_a
+      end in
+    ret flushed_err.
 
 End GenerationState.
 
 Section TypGenerators.
-  (*filter all the (ident, typ) in ctx such that typ is a ptr*)
-  Definition filter_ptr_typs (typ_ctx : type_context) (ctx : var_context) : var_context :=
-    filter (fun '(_, t) => match normalize_type typ_ctx t with
-                        | TYPE_Pointer _ => true
-                        | _ => false
-                        end) ctx.
+  Definition assign_if {m : Type -> Type} {s a b : Type} `{HM : Monad m} `{ST : @MonadState s m}
+    (cnd : bool) (l : ASetter s s a b) (v : b) : m unit
+    := if cnd then l .= v;; ret tt else ret tt.
 
-  Definition filter_sized_ptr_typs (typ_ctx : type_context) (ctx : var_context) : var_context :=
-    filter (fun '(_, t) => match normalize_type typ_ctx t with
-                        | TYPE_Pointer t => is_sized_type typ_ctx t
-                        | _ => false
-                        end) ctx.
+  Definition bool_setter (cnd : bool) : Update unit
+    := if cnd then SetValue _ tt else Unset _.
 
-  Definition filter_sized_typs (typ_ctx: type_context) (ctx : var_context) : var_context :=
-    filter (fun '(_, t) => is_sized_type typ_ctx t) ctx.
+  Definition GenQuery' m := QueryT Metadata m.
+  Definition runGenQuery {m A E}
+    `{TE : ToEnt E}
+    `{Monad m}
+    `{MS: MetadataStore m Metadata (SystemState GenState m)}
+    `{MT: MonadT (SystemT GenState m) m}
+    (q : GenQuery' m A) (k : E) : SystemT GenState m (option A):=
+    let e := toEnt k in
+    meta <- getEntity e;;
+    lift (unQueryT q e meta).
+  Definition GenQuery := GenQuery' G.
 
-  Definition filter_non_void_typs (typ_ctx : type_context) (ctx : var_context) : var_context :=
-    filter (fun '(_, t) => match normalize_type typ_ctx t with
-                        | TYPE_Void => false
-                        | _ => true
-                        end) ctx.
+  Definition runGenQueryLLVM {A E} `{TE : ToEnt E}
+    (q : GenQuery A) (k : E) : GenLLVM (option A):=
+    lift (runGenQuery q k).
 
-  Definition filter_agg_typs (typ_ctx : type_context) (ctx: var_context) : var_context :=
-    filter (fun '(_, t) =>
-              match normalize_type typ_ctx t with
-              | TYPE_Array sz _ => N.ltb 0 sz
-              | TYPE_Struct l
-              | TYPE_Packed_struct l => negb (seq.nilp l)
-              | _ => false
-              end ) ctx.
+  (* Attempt to find a matching entity in the context...
+     Note: this is not a random selection, the first thing found is returned.
+   *)
+  Definition genFind {a es E}
+    `{ToEnt E} `{Foldable es E}
+    (focus : @EntTarget es E _ _ GenState G)
+    (filter : GenQuery a)
+    : GenLLVM (option a)
+    := lift (efind focus filter).
 
-  Definition filter_vec_typs (typ_ctx : type_context) (ctx: var_context) : var_context :=
-    filter (fun '(_, t) =>
-              match normalize_type typ_ctx t with
-              | TYPE_Vector _ _ => true
-              | _ => false
-              end) ctx.
+  (* Normalize a type using the GenState to look up type aliases *)
+  Program Fixpoint normalize_type_GenLLVM (t : typ) : GenLLVM typ :=
+    match t with
+    | TYPE_Array sz t =>
+        nt <- normalize_type_GenLLVM t;;
+        ret (TYPE_Array sz nt)
 
-  Definition filter_ptr_vecptr_typs (typ_ctx : type_context) (ctx: var_context) : var_context :=
-    filter (fun '(_, t) =>
-              match normalize_type typ_ctx t with
-              | TYPE_Pointer _ => true
-              | TYPE_Vector _ (TYPE_Pointer _) => true
-              | _ => false
-              end) ctx.
+    | TYPE_Function ret_t args varargs =>
+        nret <- normalize_type_GenLLVM ret_t;;
+        nargs <- map_monad normalize_type_GenLLVM args;;
+        ret (TYPE_Function nret nargs varargs)
 
-  Definition filter_sized_ptr_vecptr_typs (typ_ctx : type_context) (ctx: var_context) : var_context :=
-    filter (fun '(_, t) =>
-              match normalize_type typ_ctx t with
-              | TYPE_Pointer t => is_sized_type typ_ctx t
-              | TYPE_Vector _ (TYPE_Pointer t) => is_sized_type typ_ctx t
-              | _ => false
-              end) ctx.
+    | TYPE_Struct fields =>
+        nfields <- map_monad normalize_type_GenLLVM fields;;
+        ret (TYPE_Struct nfields)
 
-  (* TODO: These currently don't generate pointer types either. *)
+    | TYPE_Packed_struct fields =>
+        nfields <- map_monad normalize_type_GenLLVM fields;;
+        ret (TYPE_Packed_struct nfields)
+
+    | TYPE_Vector sz t =>
+        nt <- normalize_type_GenLLVM t;;
+        ret (TYPE_Vector sz nt)
+
+    | TYPE_Identified id =>
+        ot <- genFind
+               (use (gen_context' .@ type_alias'))
+               (n <- queryl name';;
+                if Ident.eq_dec id n
+                then queryl type_alias'
+                else mzero);;
+        match ot with
+        | Some t' =>
+            normalize_type_GenLLVM t'
+        | None =>
+            ret (TYPE_Identified id)
+        end
+    | TYPE_I sz => ret t
+    | TYPE_IPTR => ret t
+    | TYPE_Pointer (Some t') =>
+        pt <- normalize_type_GenLLVM t';;
+        ret (TYPE_Pointer (Some pt))
+    | TYPE_Pointer None => ret t
+    | TYPE_Void => ret t
+    | TYPE_FP fp => ret t
+    | TYPE_Label => ret t
+    | TYPE_Token => ret t
+    | TYPE_Metadata => ret t
+    | TYPE_X86_mmx => ret t
+    | TYPE_Opaque => ret t
+    end.
+
+  (* Only works correctly if the type is well formed *)
+  Definition is_sized_type (t : typ) : GenLLVM bool
+    := t' <- normalize_type_GenLLVM t;;
+       ret (is_sized_type_h t').
+
+  (* TODO: handle opaque PTR *)
+  Definition typ_metadata_setter (τ : typ) : GenLLVM (Metadata SetterOf) :=
+    normalized <- normalize_type_GenLLVM τ;;
+    let st := is_sized_type_h normalized in
+    ret (def
+         & (@normalized_type' SetterOf .~ SetValue _ normalized)
+         & (@is_sized' SetterOf .~ bool_setter st)
+         & (@is_pointer' SetterOf .~ bool_setter (match τ with | TYPE_Pointer _ => true | _ => false end))
+         & (@is_sized_pointer' SetterOf .~
+              bool_setter
+              (match τ with
+               | TYPE_Pointer τ' => st
+               | _ => false
+               end))
+         & (@is_aggregate' SetterOf .~
+              bool_setter
+              (match normalized with
+               | TYPE_Array _ _
+               | TYPE_Struct _
+               | TYPE_Packed_struct _ => true
+               | _ => false
+               end))
+         & (@is_indexable' SetterOf .~
+              bool_setter
+              (match normalized with
+               | TYPE_Array sz _ => N.ltb 0 sz
+               | TYPE_Struct l
+               | TYPE_Packed_struct l => negb (l_is_empty l)
+               | _ => false
+               end))
+         & (@is_non_void' SetterOf .~
+              bool_setter
+              (match normalized with
+               | TYPE_Void => false
+               | _ => true
+               end))
+         & (@is_vector' SetterOf .~
+              bool_setter
+              (match normalized with
+               | TYPE_Vector _ _ => true
+               | _ => false
+               end))
+         & (@is_ptr_vector' SetterOf .~
+              bool_setter
+              (match normalized with
+               | TYPE_Pointer _ => true
+               | TYPE_Vector _ (TYPE_Pointer _) => true
+               | _ => false
+               end))
+         & (@is_sized_ptr_vector' SetterOf .~
+              bool_setter
+              (match normalized with
+               | TYPE_Pointer t => st
+               | TYPE_Vector _ (TYPE_Pointer t) => st
+               | _ => false
+               end))
+         & (@is_first_class_type' SetterOf .~
+              bool_setter
+              (match normalized with
+               | TYPE_Struct _
+               | TYPE_Packed_struct _ => false
+               | TYPE_Array _ _ => false
+               | TYPE_Pointer (Some (TYPE_Function _ _ _)) => false
+               | _ => true
+               end))
+         & (@is_function_pointer' SetterOf .~
+              bool_setter (is_function_pointer_h normalized))).
+
+  Definition set_typ_metadata (e : Ent) (τ : typ) : GenLLVM unit
+    := setter <- typ_metadata_setter τ;;
+       lift (setEntity e setter).
+
+  Definition add_to_local_ctx (x : (ident * typ)) : GenLLVM Ent
+    := let '(n, t) := x in
+       e <- lift newEntity;;
+       (gen_context' .@ entl e .@ is_local') .= ret tt;;
+       (gen_context' .@ entl e .@ name') .= ret n;;
+       (gen_context' .@ entl e .@ variable_type') .= ret t;;
+       (* Default to deterministic *)
+       (gen_context' .@ entl e .@ deterministic') .= true;;
+       set_typ_metadata e t;;
+       ret e.
+
+  Definition genLocalEnt (τ : typ) : GenLLVM (ident * Ent)
+    :=  n <- ID_Local <$> new_local_id;;
+        e <- add_to_local_ctx (n, τ);;
+        ret (n, e).
+
+  Definition genLocal (τ : typ) : GenLLVM ident
+    :=  fst <$> genLocalEnt τ.
+
+  Definition add_to_global_ctx (x : (ident * typ)) : GenLLVM Ent
+    := let '(n, t) := x in
+       e <- lift newEntity;;
+       (gen_context' .@ entl e .@ is_global') .= ret tt;;
+       (gen_context' .@ entl e .@ name') .= ret n;;
+       (gen_context' .@ entl e .@ variable_type') .= ret t;;
+       (* Default to deterministic *)
+       (gen_context' .@ entl e .@ deterministic') .= true;;
+       set_typ_metadata e t;;
+       ret e.
+
+  Definition genGlobalEnt (τ : typ) : GenLLVM (ident * Ent)
+    :=  n <- ID_Global <$> new_global_id;;
+        e <- add_to_global_ctx (n, τ);;
+        ret (n, e).
+
+  Definition genGlobal (τ : typ) : GenLLVM ident
+    := fst <$> genGlobalEnt τ.
+
+  (* A little uncertain about this. Should void instructions have
+  names? Cannot refer to their results anyway, so maybe not? *)
+  Definition genVoidEnt : GenLLVM (instr_id * Ent)
+    :=  e <- lift newEntity;;
+        n <- new_void_id;;
+       set_typ_metadata e TYPE_Void;;
+       ret (n, e).
+
+  Definition genVoid : GenLLVM instr_id
+    :=  fmap fst genVoidEnt.
+
+  (* Generate an id for the instruction given the return type *)
+  Definition genInstrIdEnt (τ : typ) : GenLLVM (instr_id * Ent)
+    := match τ with
+       | TYPE_Void => genVoidEnt
+       | _ => (fun '(n, e) => (IId (ident_to_raw_id n), e)) <$> genLocalEnt τ
+       end.
+
+  (* Generate an id for the instruction given the return type *)
+  Definition genInstrId (τ : typ) : GenLLVM instr_id
+    := match τ with
+       | TYPE_Void => genVoid
+       | _ => (fun (n : ident) => IId (ident_to_raw_id n)) <$> genLocal τ
+       end.
+
+  Definition add_to_typ_ctx (x : (ident * typ)) : GenLLVM unit
+    := let '(n, t) := x in
+       e <- lift newEntity;;
+       (gen_context' .@ entl e .@ name') .= ret n;;
+       (gen_context' .@ entl e .@ type_alias') .= ret t;;
+       set_typ_metadata e t;;
+       st <- use (gen_context' .@ entl e .@ is_sized');;
+       (gen_context' .@ entl e .@ is_sized_type_alias') .= st;;
+       (gen_context' .@ entl e .@ is_sized') .= None;;
+       (* Disable type alias usage for now. See https://github.com/vellvm/vellvm/issues/361 *)
+       (gen_context' .@ entl e .@ type_alias') .= None;;
+       (gen_context' .@ entl e .@ is_sized_type_alias') .= None;;
+       ret tt.
+
+  (* Should this be a local? *)
+  Definition add_to_ptrtoint_ctx (x : (typ * ident * Ent)) : GenLLVM unit
+    := let '(t, name, ptr) := x in
+       e <- lift newEntity;;
+       (gen_context' .@ entl e .@ name') .= ret name;;
+       (gen_context' .@ entl e .@ is_local') .= ret tt;;
+       (gen_context' .@ entl e .@ from_pointer') .= ret ptr;;
+       (* non-deterministic if the pointer is (could have
+          deterministic pointers like null) *)
+       d <- use (gen_context' .@ entl ptr .@ deterministic');;
+       (gen_context' .@ entl e .@ deterministic') .= d;;
+       set_typ_metadata e t;;
+       ret tt.
+
+
+  (* (*filter all the (ident, typ) in ctx such that typ is a ptr*) *)
+  (* Definition filter_ptr_typs (typ_ctx : type_context) (ctx : var_context) : var_context := *)
+  (*   filter (fun '(_, t) => match normalize_type typ_ctx t with *)
+  (*                       | TYPE_Pointer _ => true *)
+  (*                       | _ => false *)
+  (*                       end) ctx. *)
+
+  (* Definition filter_sized_ptr_typs (typ_ctx : type_context) (ctx : var_context) : var_context := *)
+  (*   filter (fun '(_, t) => match normalize_type typ_ctx t with *)
+  (*                       | TYPE_Pointer t => is_sized_type typ_ctx t *)
+  (*                       | _ => false *)
+  (*                       end) ctx. *)
+
+  (* Definition filter_sized_typs (typ_ctx: type_context) (ctx : var_context) : var_context := *)
+  (*   filter (fun '(_, t) => is_sized_type typ_ctx t) ctx. *)
+
+  (* Definition filter_non_void_typs (typ_ctx : type_context) (ctx : var_context) : var_context := *)
+  (*   filter (fun '(_, t) => match normalize_type typ_ctx t with *)
+  (*                       | TYPE_Void => false *)
+  (*                       | _ => true *)
+  (*                       end) ctx. *)
+
+  (* Definition filter_agg_typs (typ_ctx : type_context) (ctx: var_context) : var_context := *)
+  (*   filter (fun '(_, t) => *)
+  (*             match normalize_type typ_ctx t with *)
+  (*             | TYPE_Array sz _ => N.ltb 0 sz *)
+  (*             | TYPE_Struct l *)
+  (*             | TYPE_Packed_struct l => negb (l_is_empty l) *)
+  (*             | _ => false *)
+  (*             end ) ctx. *)
+
+  (* Definition filter_vec_typs (typ_ctx : type_context) (ctx: var_context) : var_context := *)
+  (*   filter (fun '(_, t) => *)
+  (*             match normalize_type typ_ctx t with *)
+  (*             | TYPE_Vector _ _ => true *)
+  (*             | _ => false *)
+  (*             end) ctx. *)
+
+  (* Definition filter_ptr_vecptr_typs (typ_ctx : type_context) (ctx: var_context) : var_context := *)
+  (*   filter (fun '(_, t) => *)
+  (*             match normalize_type typ_ctx t with *)
+  (*             | TYPE_Pointer _ => true *)
+  (*             | TYPE_Vector _ (TYPE_Pointer _) => true *)
+  (*             | _ => false *)
+  (*             end) ctx. *)
+
+  (* Definition filter_sized_ptr_vecptr_typs (typ_ctx : type_context) (ctx: var_context) : var_context := *)
+  (*   filter (fun '(_, t) => *)
+  (*             match normalize_type typ_ctx t with *)
+  (*             | TYPE_Pointer t => is_sized_type typ_ctx t *)
+  (*             | TYPE_Vector _ (TYPE_Pointer t) => is_sized_type typ_ctx t *)
+  (*             | _ => false *)
+  (*             end) ctx. *)
+
+  Definition gen_IntMapRaw_key_filter {a b} (m : IM.Raw.t a) (filter : GenQuery b) : GenLLVM (option Z)
+    := '(g, _) <- (IM.Raw.fold
+                    (fun key _ (grest : GenLLVM (option Z * N)) =>
+                       cnd <- is_some <$> runGenQueryLLVM filter key;;
+                       '(gacc, k) <- grest;;
+                       swap <- lift (fmap (N.eqb 0) (choose (0%N, k)));;
+                       let k' := if cnd then (k+1)%N else k in
+                       if swap && cnd
+                       then (* swap *)
+                         ret (Some key, k')
+                       else (* No swap *)
+                         ret (gacc, k'))
+                    m (ret (@None Z, 0%N)));;
+       ret g.
+
+  Definition gen_IntMapRaw_filter {a b} (m : IM.Raw.t a) (filter : GenQuery b) : GenLLVM (option b)
+    := '(g, _) <- (IM.Raw.fold
+                    (fun key _ (grest : GenLLVM (option b * N)) =>
+                       qres <- runGenQueryLLVM filter key;;
+                       let cnd := is_some qres in
+                       '(gacc, k) <- grest;;
+                       swap <- lift (fmap (N.eqb 0) (choose (0%N, k)));;
+                       let k' := if cnd then (k+1)%N else k in
+                       if swap && cnd
+                       then (* swap *)
+                         ret (qres, k')
+                       else (* No swap *)
+                         ret (gacc, k'))
+                    m (ret (@None b, 0%N)));;
+       ret g.
+
+  Definition gen_IntMapRaw_key {a} (m : IM.Raw.t a) : GenLLVM (option Z)
+    := gen_IntMapRaw_key_filter m (ret tt).
+
+  Definition gen_IntMapRaw_ent {a} (m : IM.Raw.t a) : GenLLVM (option Ent)
+    := fmap (fmap mkEnt) (gen_IntMapRaw_key m).
+
+  Definition gen_IntMapRaw_ent_filter {a b} (m : IM.Raw.t a) (filter : GenQuery b) : GenLLVM (option Ent)
+    := fmap (fmap mkEnt) (gen_IntMapRaw_key_filter m filter).
+
+  Definition gen_sized_type_alias : GenLLVM (option ident)
+    := es <- use (gen_context' .@ is_sized_type_alias');;
+       var <- gen_IntMapRaw_ent_filter es (withoutl is_function_pointer');;
+       match var with
+       | Some var =>
+           id <- use (gen_context' .@ entl var .@ name');;
+           ret id
+       | None => ret None
+       end.
+
+  Definition gen_entity_with {a} (focus : Lens' (SystemState GenState G) (IM.Raw.t a)): GenLLVM (option Ent)
+    := es <- use focus;;
+       gen_IntMapRaw_ent es.
+
+  Definition gen_entity_with_filter {a b}
+    (focus : Lens' (SystemState GenState G) (IM.Raw.t a))
+    (filter : GenQuery b)
+    : GenLLVM (option Ent)
+    := es <- use focus;;
+       gen_IntMapRaw_ent_filter es filter.
+
+  (* Randomly select from all matching entities in the context *)
+  Definition gen_foldable_filter_ent {b es E} `{ToEnt E} `{Foldable es E}
+    (m : es) (filter : GenQuery b) : GenLLVM (option (Ent * b))
+    := '(g, _) <- (fold _
+                    (fun key (grest : GenLLVM (option (Ent * b) * N)) =>
+                       qres <- runGenQueryLLVM filter key;;
+                       let cnd := is_some qres in
+                       '(gacc, k) <- grest;;
+                       swap <- lift (fmap (N.eqb 0) (choose (0%N, k)));;
+                       let k' := if cnd then (k+1)%N else k in
+                       if swap && cnd
+                       then (* swap *)
+                         ret (fmap (fun x => (toEnt key, x)) qres, k')
+                       else (* No swap *)
+                         ret (gacc, k'))
+                    (ret (@None (Ent * b), 0%N))) m;;
+       ret g.
+
+  Definition gen_foldable_filter {b es E} `{ToEnt E} `{Foldable es E}
+    (m : es) (filter : GenQuery b) : GenLLVM (option b)
+    := fmap snd <$> gen_foldable_filter_ent m filter.
+
+  Definition genMatchEnt {a es E}
+    `{ToEnt E} `{Foldable es E}
+    (focus : @EntTarget es E _ _ GenState G)
+    (filter : GenQuery a)
+    : GenLLVM (option (Ent * a))
+    := es <- lift focus;;
+       gen_foldable_filter_ent es filter.
+
+  Definition genMatch {a es E}
+    `{ToEnt E} `{Foldable es E}
+    (focus : @EntTarget es E _ _ GenState G)
+    (filter : GenQuery a)
+    : GenLLVM (option a)
+    := es <- lift focus;;
+       gen_foldable_filter es filter.
+
+  Definition get_type_from_alias (var : Ent) : GenLLVM typ
+    := mident <- use (gen_context' .@ entl var .@ type_alias');;
+       match mident with
+       | Some id => ret id
+       | None => failGen "gen_sized_type_alias, couldn't find entity... Shouldn't happen"
+       end.
+
+  Definition get_type_of_variable (var : Ent) : GenLLVM typ
+    := mident <- use (gen_context' .@ entl var .@ variable_type');;
+       match mident with
+       | Some id => ret id
+       | None => failGen "gen_sized_type_alias, couldn't find entity... Shouldn't happen"
+       end.
+
+  (* Generate a type that matches one of the type aliases *)
+  Definition gen_sized_type_of_alias {a} (focus : Lens' (SystemState GenState G) (IM.Raw.t a)) : GenLLVM typ
+    := var <- gen_entity_with focus;;
+       match var with
+       | Some var =>
+           get_type_from_alias var
+       | None => failGen "gen_sized_type_of_alias, couldn't find entity... Shouldn't happen"
+       end.
+
+  Definition gen_sized_type_of_alias_filter {a b}
+    (focus : Lens' (SystemState GenState G) (IM.Raw.t a))
+    (filter : GenQuery b)
+    : GenLLVM (option typ)
+    := var <- gen_entity_with_filter focus filter;;
+       match var with
+       | Some var => fmap Some (get_type_from_alias var)
+       | None => ret None
+       end.
+
+  (* Generate a type that matches one of the variables *)
+  Definition gen_type_of_variable_filter {a b}
+    (focus : Lens' (SystemState GenState G) (IM.Raw.t a))
+    (filter : GenQuery b)
+    : GenLLVM (option typ)
+    := var <- gen_entity_with_filter focus filter;;
+       match var with
+       | Some var => fmap Some (get_type_of_variable var)
+       | None => ret None
+       end.
 
   (* Not sized in the QuickChick sense, sized in the LLVM sense. *)
   Definition gen_sized_typ_0 : GenLLVM typ :=
-    aliases <- get_typ_ctx;;
-    let sized_aliases := filter (fun '(i,t) => is_sized_type aliases t) aliases in
+    oid <- gen_sized_type_alias;;
     let ident_gen :=
-        (* Don't want to fail if there are no identifiers *)
-        if (List.length sized_aliases =? 0)%nat
-        then []
-        else [ret TYPE_Identified <*> oneOf_LLVM (map (fun '(i,_) => ret i) sized_aliases)] in
+      match oid with
+      | None => []
+      | Some id => [ret (TYPE_Identified id)]
+      end
+    in
     oneOf_LLVM
-           (ident_gen ++
-           (map ret
-                [ TYPE_I 1
-                ; TYPE_I 8
-                ; TYPE_I 32
-                (* TODO: big ints *)
-                (* ; TYPE_I 64 *)
-                (* TODO: Generate floats and stuff *)
-                ; TYPE_Float
-                (* ; TYPE_Double *)
-                (* TODO: Could generate TYPE_Identified if we filter for sized types *)
-                (* ; TYPE_Half *)
-                (* ; TYPE_X86_fp80 *)
-                (* ; TYPE_Fp128 *)
-                (* ; TYPE_Ppc_fp128 *)
-                (* ; TYPE_Metadata *)
-                (* ; TYPE_X86_mmx *)
-                (* ; TYPE_Opaque *)
-           ])).
+      (ident_gen ++
+         (map ret
+            ([ TYPE_I 1
+               ; TYPE_I 8
+               ; TYPE_I 16
+               ; TYPE_I 32
+               ; TYPE_I 64
+                        (* TODO: Could generate TYPE_Identified if we filter for sized types *)
+                        (* ; TYPE_Half *)
+                        (* ; TYPE_X86_fp80 *)
+                        (* ; TYPE_Fp128 *)
+                        (* ; TYPE_Ppc_fp128 *)
+                        (* ; TYPE_Metadata *)
+                        (* ; TYPE_X86_mmx *)
+                        (* ; TYPE_Opaque *)
+              ] ++
+               (if enable_float_generation
+                then
+                 [ (* TODO: Generate floats and stuff *)
+                   TYPE_FP FP_float
+                 ]
+               else
+                 [])
+         ))).
 
-  Program Fixpoint gen_sized_typ_size (sz : nat) {measure sz} : GenLLVM typ :=
+  (* TODO: Move this *)
+  Definition lengthN {X} (xs : list X) : N :=
+    fold_left (fun acc x => (acc + 1)%N) xs 0%N.
+
+  (* Definition gen_typ_from_ctx (ctx : var_context) : GenLLVM typ *)
+  (*   := fmap snd (elems_LLVM ctx). *)
+
+  (* Definition gen_ident_from_ctx (ctx : var_context) : GenLLVM ident *)
+  (*   := fmap fst (elems_LLVM ctx). *)
+
+  Definition def_option_GenLLVM {a} (def : GenLLVM a) (gopt : GenLLVM (option a)) : GenLLVM a
+    := o <- gopt;;
+       match o with
+       | Some a => ret a
+       | None => def
+       end.
+
+  Definition gen_type_matching_alias_focus {a b}
+    (focus : Lens' (SystemState GenState G) (IM.Raw.t a)) (filter : GenQuery b)
+    : GenLLVM (option typ)
+    := gen_sized_type_of_alias_filter focus filter.
+
+  Definition gen_type_matching_variable_focus {a b}
+    (focus : Lens' (SystemState GenState G) (IM.Raw.t a)) (filter : GenQuery b)
+    : GenLLVM (option typ)
+    := gen_type_of_variable_filter focus filter.
+
+  Definition gen_type_matching_alias {b} (filter : GenQuery b) : GenLLVM (option typ)
+    := gen_type_matching_alias_focus (gen_context' .@ is_sized_type_alias') filter.
+
+  Definition gen_type_matching_local {b} (filter : GenQuery b) : GenLLVM (option typ)
+    := gen_type_matching_variable_focus (gen_context' .@ is_local') filter.
+
+  Definition gen_type_matching_global {b} (filter : GenQuery b) : GenLLVM (option typ)
+    := gen_type_matching_variable_focus (gen_context' .@ is_global') filter.
+
+  Definition gen_type_matching_variable {b} (filter : GenQuery b) : GenLLVM (option typ)
+    := gen_type_matching_variable_focus (gen_context' .@ variable_type') filter.
+
+  Definition gen_primitive_typ : GenLLVM typ :=
+    oneOf_LLVM
+      ([ret (TYPE_I 1)
+        ; ret (TYPE_I 8)
+        ; ret (TYPE_I 16)
+        ; ret (TYPE_I 32)
+        ; ret (TYPE_I 64)
+        ] ++ if enable_float_generation then [ret (TYPE_FP FP_float) (* ; ret TYPE_DOUBLE *)] else []).
+
+  Definition sized_aggregate_typ_gens (subg : nat -> GenLLVM typ) (sz : nat) :  list (unit -> GenLLVM typ)
+    := [ (fun _ => gen_sized_typ_0)
+       ; (fun _ => ret (fun t => TYPE_Pointer (Some t)) <*> subg sz)
+       (* TODO: Might want to restrict the size to something reasonable *)
+       ; (fun _ => ret TYPE_Array <*> lift_GenLLVM genN <*> subg sz)
+       ; (fun _ => ret TYPE_Vector <*> (n <- lift_GenLLVM genN;; ret (n + 1)%N) <*> gen_primitive_typ)
+       ; (fun _ => ret TYPE_Struct <*> nonemptyListOf_LLVM (subg sz))
+       ; (fun _ => ret TYPE_Packed_struct <*> nonemptyListOf_LLVM (subg sz))
+    ].
+
+  Fixpoint gen_typ_size'
+    (baseGen : GenLLVM typ)
+    (aggregate_gens : (nat -> GenLLVM typ) -> nat -> list (unit -> GenLLVM typ))
+    (from_context : GenLLVM (option typ)) (sz : nat)
+    {struct sz} : GenLLVM typ :=
     match sz with
-    | O => gen_sized_typ_0
+    | O => baseGen
     | (S sz') =>
-        ctx <- get_ctx;;
-        aliases <- get_typ_ctx;;
-        let typs_in_ctx := map (fun '(_, typ) => ret typ) (filter_sized_typs aliases ctx) in
-        freq_LLVM_thunked
-        ([(min (List.length typs_in_ctx) 10, (fun _ => oneOf_LLVM typs_in_ctx))] ++
-         [(1%nat, (fun _ => gen_sized_typ_0))
-        ; (1%nat, (fun _ => ret TYPE_Pointer <*> gen_sized_typ_size sz'))
-        (* TODO: Might want to restrict the size to something reasonable *)
-        ; (1%nat, (fun _ => ret TYPE_Array <*> lift_GenLLVM genN <*> gen_sized_typ_size sz'))
-        ; (1%nat, (fun _ => ret TYPE_Vector <*> (n <- lift_GenLLVM genN;; ret (n + 1)%N) <*> gen_sized_typ_size 0))
-        (* TODO: I don't think functions are sized types? *)
-        (* ; let n := Nat.div sz 2 in *)
-        (*   ret TYPE_Function <*> gen_sized_typ_size n <*> listOf_LLVM (gen_sized_typ_size n) *)
-        ; (1%nat, (fun _ => ret TYPE_Struct <*> nonemptyListOf_LLVM (gen_sized_typ_size sz')))
-        ; (1%nat, (fun _ => ret TYPE_Packed_struct <*> nonemptyListOf_LLVM (gen_sized_typ_size sz')))
-          ])
+        ofc <- from_context;;
+        let fc : list (N * (unit -> GenLLVM typ)) :=
+          match ofc with
+          | None => []
+          | Some fc =>
+              [(10%N, fun _ : unit => ret fc)]
+          end
+        in
+        let aggregates := (sized_aggregate_typ_gens (fun sz => @gen_typ_size' baseGen aggregate_gens from_context sz) sz') in
+        freq_LLVM_thunked_N (fc ++ fmap (fun x => (1%N, x)) aggregates)
     end.
-  Next Obligation.
-  lia.
-  Defined.
 
-  Definition gen_sized_typ : GenLLVM typ
-    := sized_LLVM (fun sz => gen_sized_typ_size sz).
+  Definition gen_sized_typ_size :=
+    gen_typ_size' gen_sized_typ_0 sized_aggregate_typ_gens (gen_type_matching_variable (withl is_sized')).
 
- Program Fixpoint gen_sized_typ_size_ptrinctx (sz : nat) {measure sz} : GenLLVM typ :=
-    match sz with
-    | 0%nat => gen_sized_typ_0
-    | (S sz') =>
-        ctx <- get_ctx;;
-        aliases <- get_typ_ctx;;
-        let typs_in_ctx := map (fun '(_, typ) => ret typ) (filter_sized_typs aliases ctx) in
-        freq_LLVM_thunked
-        ([(min (List.length typs_in_ctx) 10, (fun _ => oneOf_LLVM typs_in_ctx))] ++
-        [(1%nat, (fun _ => gen_sized_typ_0))
-        (* TODO: Might want to restrict the size to something reasonable *)
-        ; (1%nat, (fun _ => ret TYPE_Array <*> lift_GenLLVM genN <*> gen_sized_typ_size_ptrinctx sz'))
-        ; (1%nat, (fun _ => ret TYPE_Vector <*> (n <- lift_GenLLVM genN;; ret (n + 1)%N) <*> gen_sized_typ_size_ptrinctx 0))
-        (* TODO: I don't think functions are sized types? *)
-        (* ; let n := Nat.div sz 2 in *)
-        (*   ret TYPE_Function <*> gen_sized_typ_size n <*> listOf_LLVM (gen_sized_typ_size n) *)
-        ; (1%nat, (fun _ => ret TYPE_Struct <*> nonemptyListOf_LLVM (gen_sized_typ_size_ptrinctx sz')))
-        ; (1%nat, (fun _ => ret TYPE_Packed_struct <*> nonemptyListOf_LLVM (gen_sized_typ_size_ptrinctx sz')))])
-    end.
-  Next Obligation.
-  lia.
-  Defined.
+  Definition max_typ_size : nat := 4.
 
-  Definition gen_sized_typ_ptrinctx : GenLLVM typ
-    := sized_LLVM (fun sz => gen_sized_typ_size_ptrinctx sz).
+  Definition gen_sized_typ  : GenLLVM typ
+    := sized_LLVM (fun sz => gen_sized_typ_size (min sz max_typ_size)).
+
+(*   (* Want to be able to use gen_sized_typ' to do this... *)
+(*      But I did not notice this wants only sized types from the contexts. *)
+(*      Need to be able to filter focused entities to only the ones with the sized type tags... Should be doable. *)
+(*    *) *)
+(*   Definition gen_sized_typ_ptrin_fctx : GenLLVM typ *)
+(*     := gen_typ_size' ( *)
+(*     ctx <- get_ctx;; *)
+(*     aliases <- get_typ_ctx;; *)
+(*     let typs_in_ctx := filter_sized_typs aliases ctx in *)
+(*     sized_LLVM (fun sz => gen_sized_typ_size_ptrinctx sz typs_in_ctx). *)
+
+(* gen_sized_typ_ptrin_fctx seems to grab a  *)
+
+(*   Definition gen_sized_typ_ptrin_gctx : GenLLVM typ *)
+(*     := *)
+(*     gctx <- get_global_ctx;; *)
+(*     aliases <- get_typ_ctx;; *)
+(*     let typs_in_ctx := filter_sized_typs aliases gctx in *)
+(*     sized_LLVM (fun sz => gen_sized_typ_size_ptrinctx sz typs_in_ctx). *)
+
+  Definition gen_type_alias_ident : GenLLVM (option ident)
+    := es <- use (gen_context' .@ type_alias');;
+       var <- gen_IntMapRaw_ent es;;
+       match var with
+       | Some var =>
+           id <- use (gen_context' .@ entl var .@ name');;
+           ret id
+       | None => ret None
+       end.
 
   (* Generate a type of size 0 *)
   Definition gen_typ_0 : GenLLVM typ :=
-    aliases <- get_typ_ctx;;
-    let identified :=
-        match aliases with
-        | [] => []
-        | _  => [(ret TYPE_Identified <*> oneOf_LLVM (map (fun '(i,_) => ret i) aliases))]
-        end
-    in
+    oid <- gen_sized_type_alias;;
+    (* let ident_gen := *)
+    (*   match oid with *)
+    (*   | None => [] *)
+    (*   | Some id => [ret (TYPE_Identified id)] *)
+    (*   end *)
+    (* in *)
     oneOf_LLVM
           ((* identified ++ *)
            (map ret
-                [ TYPE_I 1
+                ([ TYPE_I 1
                 ; TYPE_I 8
+                ; TYPE_I 16
                 ; TYPE_I 32
-                (* TODO: big ints*)
-               (* ; TYPE_I 64 *)
+                ; TYPE_I 64
                 ; TYPE_Void
-                (* TODO: Generate floats and stuff *)
-                ; TYPE_Float
-                (*; TYPE_Double*)
-                (* ; TYPE_Half *)
-                (* ; TYPE_X86_fp80 *)
-                (* ; TYPE_Fp128 *)
-                (* ; TYPE_Ppc_fp128 *)
                 (* ; TYPE_Metadata *)
                 (* ; TYPE_X86_mmx *)
                 (* ; TYPE_Opaque *)
-                ])).
+                ] ++
+                   (if enable_float_generation
+                    then
+                      [ (* TODO: Generate floats and stuff *)
+                        TYPE_FP FP_float
+                          (* ; TYPE_Double *)
+                          (* ; TYPE_Half *)
+                          (* ; TYPE_X86_fp80 *)
+                          (* ; TYPE_Fp128 *)
+                          (* ; TYPE_Ppc_fp128 *)
+                      ]
+                    else
+                      [])))).
+
+
+  Definition aggregate_typ_gens (subg : nat -> GenLLVM typ) (sz : nat) :  list (unit -> GenLLVM typ)
+    := [ (fun _ => subg 0%nat)
+       ; (fun _ => ret (fun t => TYPE_Pointer (Some t)) <*> subg sz)
+       (* TODO: Might want to restrict the size to something reasonable *)
+       ; (fun _ => ret TYPE_Array <*> lift_GenLLVM genN <*> subg sz)
+       ; (fun _ => ret TYPE_Vector <*> (n <- lift_GenLLVM genN;; ret (n + 1)%N) <*> gen_primitive_typ)
+       ; (fun _ =>
+          let n := Nat.div (S sz) 2 in
+          ret TYPE_Function <*> subg n <*> listOf_LLVM (gen_sized_typ_size n) <*> ret false)
+       ; (fun _ => ret TYPE_Struct <*> nonemptyListOf_LLVM (subg sz))
+       ; (fun _ => ret TYPE_Packed_struct <*> nonemptyListOf_LLVM (subg sz))
+    ].
 
   (* TODO: This should probably be mutually recursive with
      gen_sized_typ since pointers of any type are considered sized *)
-  Program Fixpoint gen_typ_size (sz : nat) {measure sz} : GenLLVM typ :=
-    match sz with
-    | 0%nat => gen_typ_0
-    | (S sz') =>
-        ctx <- get_ctx;;
-        (* not filter sized types for this one *)
-        let typs_in_ctx := map (fun '(_, typ) =>ret typ) ctx in
-        freq_LLVM_thunked
-        ([(min (List.length typs_in_ctx) 10, (fun _ => oneOf_LLVM typs_in_ctx))] ++
-        [ (1%nat, (fun _ => gen_typ_0)) (* TODO: Not sure if I need to add it here *)
-        (* Might want to restrict the size to something reasonable *)
-        (* TODO: Make sure length of Array >= 0, and length of vector >= 1 *)
-        ; (1%nat, (fun _ => ret TYPE_Array <*> lift genN <*> gen_sized_typ_size sz'))
-        ; (1%nat, (fun _ => ret TYPE_Vector <*> (n <- lift_GenLLVM genN;;ret (n + 1)%N) <*> gen_sized_typ_size 0))
-        ; let n := Nat.div sz 2 in
-        (1%nat, (fun _ => ret TYPE_Function <*> gen_typ_size n <*> listOf_LLVM (gen_sized_typ_size n) <*> ret false))
-        ; (1%nat, (fun _ => ret TYPE_Struct <*> nonemptyListOf_LLVM (gen_sized_typ_size sz')))
-        ; (1%nat, (fun _ => ret TYPE_Packed_struct <*> nonemptyListOf_LLVM (gen_sized_typ_size sz')))
-        ])
-    end.
-  Next Obligation.
-    cbn.
-    assert (0 <= 1)%nat by lia.
-    pose proof Nat.divmod_spec sz' 1 0 0 H0.
-    cbn; destruct (Nat.divmod sz' 1 0 0).
-    cbn; lia.
-  Qed.
+  Definition gen_typ_size : nat -> GenLLVM typ :=
+    gen_typ_size' gen_typ_0 aggregate_typ_gens (gen_type_matching_variable (ret tt)).
 
   Definition gen_typ : GenLLVM typ
-    := sized_LLVM (fun sz => gen_typ_size sz).
+    := sized_LLVM (fun sz => gen_typ_size (min sz max_typ_size)).
 
   Definition gen_typ_non_void_0 : GenLLVM typ :=
-    aliases <- get_typ_ctx;;
-    let identified :=
-        match aliases with
-        | [] => []
-        | _  => [(ret TYPE_Identified <*> oneOf_LLVM (map (fun '(i,_) => ret i) aliases))]
-        end
+    oid <- gen_sized_type_alias;;
+    let ident_gen :=
+      match oid with
+      | None => []
+      | Some id => [ret (TYPE_Identified id)]
+      end
     in
     oneOf_LLVM
-          (identified ++
-           (map ret
-                [ TYPE_I 1
-                ; TYPE_I 8
-                ; TYPE_I 32
-                (* TODO: big ints *)
-                (* ; TYPE_I 64 *)
-                (* TODO: Generate floats and stuff *)
-                ; TYPE_Float
-                (* ; TYPE_Double *)
-                (* ; TYPE_Half *)
-                (* ; TYPE_X86_fp80 *)
-                (* ; TYPE_Fp128 *)
-                (* ; TYPE_Ppc_fp128 *)
-                (* ; TYPE_Metadata *)
-                (* ; TYPE_X86_mmx *)
-                (* ; TYPE_Opaque *)
-          ])).
+      (ident_gen ++
+         (map ret
+            ([ TYPE_I 1
+               ; TYPE_I 8
+               ; TYPE_I 16
+               ; TYPE_I 32
+               ; TYPE_I 64
+                        (* ; TYPE_Metadata *)
+                        (* ; TYPE_X86_mmx *)
+                        (* ; TYPE_Opaque *)
+              ] ++ (if enable_float_generation
+                    then
+                      [ (* TODO: Generate floats and stuff *)
+                        TYPE_FP FP_float
+                          (* ; TYPE_Double *)
+                          (* ; TYPE_Half *)
+                          (* ; TYPE_X86_fp80 *)
+                          (* ; TYPE_Fp128 *)
+                          (* ; TYPE_Ppc_fp128 *)
+                      ]
+                    else
+                      [])))).
 
-  Program Fixpoint gen_typ_non_void_size (sz : nat) {measure sz} : GenLLVM typ :=
-    match sz with
-    | 0%nat => gen_typ_non_void_0
-    | (S sz') =>
-        typ_ctx <- get_typ_ctx;;
-        ctx <- get_ctx;;
-        let typs_in_ctx := map (fun '(_, typ) => ret typ) (filter_non_void_typs typ_ctx ctx) in
-        freq_LLVM_thunked
-        ([(min (List.length typs_in_ctx) 10, fun _ => oneOf_LLVM typs_in_ctx)] ++
-        [ (1%nat, fun _ => gen_typ_non_void_0)
-        (* Might want to restrict the size to something reasonable *)
-        (* TODO: Make sure length of Array >= 0, and length of vector >= 1 *)
-        ; (1%nat, fun _ => ret TYPE_Array <*> lift genN <*> gen_sized_typ_size sz')
-        ; (1%nat, fun _ => ret TYPE_Vector <*> (n <- lift_GenLLVM genN;;ret (n + 1)%N) <*> gen_sized_typ_size 0)
-        ; let n := Nat.div sz 2 in
-        (1%nat, fun _ => ret TYPE_Function <*> gen_typ_size n <*> listOf_LLVM (gen_sized_typ_size n) <*> ret false)
-        ; (1%nat, fun _ => ret TYPE_Struct <*> nonemptyListOf_LLVM (gen_sized_typ_size sz'))
-        ; (1%nat, fun _ => ret TYPE_Packed_struct <*> nonemptyListOf_LLVM (gen_sized_typ_size sz'))
-          ])
-    end.
+  Definition gen_typ_non_void_size : nat -> GenLLVM typ :=
+    gen_typ_size' gen_typ_non_void_0 aggregate_typ_gens (gen_type_matching_variable (withl is_non_void')).
 
-  Program Fixpoint gen_typ_non_void_size_wo_fn (sz : nat) {measure sz} : GenLLVM typ :=
-  match sz with
-  | 0%nat => gen_typ_non_void_0
-  | (S sz') =>
-      ctx <- get_ctx;;
-      aliases <- get_typ_ctx;;
-      let typs_in_ctx := map (fun '(_, typ) => ret typ) (filter_sized_typs aliases ctx) in
-      freq_LLVM_thunked
-      ([(min (List.length typs_in_ctx) 10, fun _ => oneOf_LLVM typs_in_ctx)] ++
-      [ (1%nat, fun _ => gen_typ_non_void_0)
-      (* Might want to restrict the size to something reasonable *)
-      (* TODO: Make sure length of Array >= 0, and length of vector >= 1 *)
-      ; (1%nat, fun _ => ret TYPE_Array <*> lift genN <*> gen_sized_typ_size sz')
-      ; (1%nat, fun _ => ret TYPE_Vector <*> (n <- lift_GenLLVM genN;;ret (n + 1)%N) <*> gen_sized_typ_size 0)
-      ; (1%nat, fun _ => ret TYPE_Struct <*> nonemptyListOf_LLVM (gen_sized_typ_size sz'))
-      ; (1%nat, fun _ => ret TYPE_Packed_struct <*> nonemptyListOf_LLVM (gen_sized_typ_size sz'))
-      ])
-  end.
+  Definition gen_typ_non_void : GenLLVM typ :=
+    sized_LLVM (fun sz => gen_typ_non_void_size (min sz max_typ_size)).
+
+  (* Non-void, non-function types *)
+  Definition gen_typ_non_void_size_wo_fn : nat -> GenLLVM typ :=
+    gen_typ_size' gen_typ_non_void_0 sized_aggregate_typ_gens (gen_type_matching_variable (withl is_non_void')).
+
+  Definition gen_typ_non_void_wo_fn : GenLLVM typ :=
+    sized_LLVM (fun sz => gen_typ_non_void_size_wo_fn (min sz max_typ_size)).
 
   (* TODO: look up identifiers *)
   (* Types for operation expressions *)
   Definition gen_op_typ : GenLLVM typ :=
     oneOf_LLVM
-           (map ret
-                [ TYPE_I 1
-                ; TYPE_I 8
-                ; TYPE_I 32
-                (* TODO: big ints *)
-                (* ; TYPE_I 64 *)
-                (* TODO: Generate floats and stuff *)
-                ; TYPE_Float
-                (* ; TYPE_Double *)
-                (* ; TYPE_Half *)
-                (* ; TYPE_X86_fp80 *)
-                (* ; TYPE_Fp128 *)
-                (* ; TYPE_Ppc_fp128 *)
-                (* ; TYPE_Metadata *)
-                (* ; TYPE_X86_mmx *)
-                (* ; TYPE_Opaque *)
-                ]).
+      (map ret
+         ([ TYPE_I 1
+            ; TYPE_I 8
+            ; TYPE_I 16
+            ; TYPE_I 32
+            ; TYPE_I 64
+                     (* ; TYPE_Metadata *)
+                     (* ; TYPE_X86_mmx *)
+                     (* ; TYPE_Opaque *)
+           ] ++ (if enable_float_generation
+                 then
+                   [ (* TODO: Generate floats and stuff *)
+                     TYPE_FP FP_float
+                       (* ; TYPE_Double *)
+                       (* ; TYPE_Half *)
+                       (* ; TYPE_X86_fp80 *)
+                       (* ; TYPE_Fp128 *)
+                       (* ; TYPE_Ppc_fp128 *)
+                   ]
+                 else
+                   []))).
 
   (* TODO: look up identifiers *)
   Definition gen_int_typ : GenLLVM typ :=
-    oneOf_LLVM
-           (map ret
-                [ TYPE_I 1
-                ; TYPE_I 8
-                ; TYPE_I 32
-                (* TODO: big ints *)
-                (* ; TYPE_I 64 *)
-           ]).
+    elems_LLVM
+      [ TYPE_I 1
+        ; TYPE_I 8
+        ; TYPE_I 16
+        ; TYPE_I 32
+        ; TYPE_I 64
+      ].
+
+  (* TODO: look up identifiers *)
+  Definition gen_float_typ : GenLLVM typ :=
+    elems_LLVM
+      [ TYPE_FP FP_float
+        (* ; TYPE_Double *)
+      ].
 
   (* TODO: IPTR not implemented *)
   Definition gen_int_typ_for_ptr_cast : GenLLVM typ :=
@@ -834,8 +1649,11 @@ End TypGenerators.
 
 Section ExpGenerators.
 
+  (* SAZ: Here there were old uses of [failGen] that I replaced (arbitrarily) with the
+     last element of the non-empty list. *)
+
   Definition gen_ibinop : G ibinop :=
-     oneOf_ failGen
+     oneOf_ (ret Xor) (* SAZ: This default case is a hack *)
            [ ret LLVMAst.Add <*> ret false <*> ret false
            ; ret Sub <*> ret false <*> ret false
            ; ret Mul <*> ret false <*> ret false
@@ -847,27 +1665,27 @@ Section ExpGenerators.
            ; ret URem
            ; ret SRem
            ; ret And
-           ; ret Or
+           ; ret (Or false)
            ; ret Xor
            ].
 
   (*Float operations*)
   Definition gen_fbinop : G fbinop :=
-    oneOf_ failGen
+    oneOf_ (ret FRem) (* SAZ: This default case is a hack *)
             [ ret LLVMAst.FAdd
             ; ret FSub
             ; ret FMul
             ; ret FDiv
-            ; ret FRem
+            (* ; ret FRem *) (* Disable FRem because vellvm doesn't support it yet *)
             ].
 
   Definition gen_icmp : G icmp :=
-    oneOf_ failGen
+    oneOf_ (ret Sle) (* SAZ: This default case is a hack *)
            (map ret
                 [ Eq; Ne; Ugt; Uge; Ult; Ule; Sgt; Sge; Slt; Sle]).
 
   Definition gen_fcmp : G fcmp :=
-    oneOf_ failGen
+    oneOf_ (ret FTrue) (* SAZ: This default case is a hack *)
             (map ret
                   [FFalse; FOeq; FOgt; FOge; FOlt; FOle; FOne; FOrd;
                    FUno; FUeq; FUgt; FUge; FUlt; FUle; FUne; FTrue]).
@@ -880,56 +1698,7 @@ Section ExpGenerators.
   (* TODO: generate conversions? *)
 
   (* TODO: Move this*)
-  Fixpoint dtyp_eq (a : dtyp) (b : dtyp) {struct a} : bool
-    := match a, b with
-       | DTYPE_I sz, DTYPE_I sz' =>
-         if N.eq_dec sz sz' then true else false
-       | DTYPE_I _, _ => false
-       | DTYPE_IPTR, DTYPE_IPTR => true
-       | DTYPE_IPTR, _ => false
-       | DTYPE_Pointer, DTYPE_Pointer => true
-       | DTYPE_Pointer, _ => false
-       | DTYPE_Void, DTYPE_Void => true
-       | DTYPE_Void, _ => false
-       | DTYPE_Half, DTYPE_Half => true
-       | DTYPE_Half, _ => false
-       | DTYPE_Float, DTYPE_Float => true
-       | DTYPE_Float, _ => false
-       | DTYPE_Double, DTYPE_Double => true
-       | DTYPE_Double, _ => false
-       | DTYPE_X86_fp80, DTYPE_X86_fp80 => true
-       | DTYPE_X86_fp80, _ => false
-       | DTYPE_Fp128, DTYPE_Fp128 => true
-       | DTYPE_Fp128, _ => false
-       | DTYPE_Ppc_fp128, DTYPE_Ppc_fp128 => true
-       | DTYPE_Ppc_fp128, _ => false
-       | DTYPE_Metadata, DTYPE_Metadata => true
-       | DTYPE_Metadata, _ => false
-       | DTYPE_X86_mmx, DTYPE_X86_mmx => true
-       | DTYPE_X86_mmx, _ => false
-       | DTYPE_Array sz t, DTYPE_Array sz' t' =>
-           if N.eq_dec sz sz'
-           then dtyp_eq t t'
-           else false
-       | DTYPE_Array _ _, _ => false
-       | DTYPE_Struct fields, DTYPE_Struct fields' =>
-         if Nat.eqb (Datatypes.length fields) (Datatypes.length fields')
-         then forallb id (map_In (zip fields fields') (fun '(a, b) HIn => dtyp_eq a b))
-         else false
-       | DTYPE_Struct _, _ => false
-       | DTYPE_Packed_struct fields, DTYPE_Packed_struct fields' =>
-         if Nat.eqb (Datatypes.length fields) (Datatypes.length fields')
-         then forallb id (map_In (zip fields fields') (fun '(a, b) HIn => dtyp_eq a b))
-         else false
-       | DTYPE_Packed_struct _, _ => false
-       | DTYPE_Opaque, DTYPE_Opaque => false (* TODO: Unsure if this should compare equal *)
-       | DTYPE_Opaque, _ => false
-       | DTYPE_Vector sz t, DTYPE_Vector sz' t' =>
-           if N.eq_dec sz sz'
-           then dtyp_eq t t'
-           else false
-       | DTYPE_Vector _ _, _ => false
-       end.
+  Definition dtyp_eq := DynamicTypes.dtyp_eqb.
 
   (* TODO: Move this*)
   (* This only returns what you expect on normalized typs *)
@@ -937,11 +1706,12 @@ Section ExpGenerators.
            identified types... It should be conservative and say that
            the types are *not* equal always, though.
    *)
+  
   Fixpoint normalized_typ_eq (a : typ) (b : typ) {struct a} : bool
     := match a with
        | TYPE_I sz =>
          match b with
-         | TYPE_I sz' => if N.eq_dec sz sz' then true else false
+         | TYPE_I sz' => if Pos.eq_dec sz sz' then true else false
          | _ => false
          end
        | TYPE_IPTR =>
@@ -951,7 +1721,12 @@ Section ExpGenerators.
          end
        | TYPE_Pointer t =>
          match b with
-         | TYPE_Pointer t' => normalized_typ_eq t t'
+         | TYPE_Pointer t' =>
+             match (t, t') with
+             | (Some t, Some t') => normalized_typ_eq t t'
+             | (None, None) => true
+             | _ => false
+             end
          | _ => false
          end
        | TYPE_Void =>
@@ -959,34 +1734,19 @@ Section ExpGenerators.
          | TYPE_Void => true
          | _ => false
          end
-       | TYPE_Half =>
+       | TYPE_FP fp1 =>
          match b with
-         | TYPE_Half => true
+         | TYPE_FP fp2 => floating_point_variant_beq fp1 fp2
          | _ => false
          end
-       | TYPE_Float =>
+       | TYPE_Label =>
          match b with
-         | TYPE_Float => true
+         | TYPE_Label => true
          | _ => false
          end
-       | TYPE_Double =>
+       | TYPE_Token =>
          match b with
-         | TYPE_Double => true
-         | _ => false
-         end
-       | TYPE_X86_fp80 =>
-         match b with
-         | TYPE_X86_fp80 => true
-         | _ => false
-         end
-       | TYPE_Fp128 =>
-         match b with
-         | TYPE_Fp128 => true
-         | _ => false
-         end
-       | TYPE_Ppc_fp128 =>
-         match b with
-         | TYPE_Ppc_fp128 => true
+         | TYPE_Token => true
          | _ => false
          end
        | TYPE_Metadata =>
@@ -1043,7 +1803,14 @@ Section ExpGenerators.
            else false
          | _ => false
          end
-       | TYPE_Identified id => false
+       | TYPE_Identified id =>
+           match b with
+           | TYPE_Identified id' =>
+               if Ident.eq_dec id id'
+               then true
+               else false
+           | _ => false
+           end
        end.
 
   (* This needs to use normalized_typ_eq, instead of dtyp_eq because of pointer types...
@@ -1071,17 +1838,15 @@ Section ExpGenerators.
         | _ => false
         end
     | TYPE_IPTR
-    | TYPE_Half
-    | TYPE_Float
-    | TYPE_Double
-    | TYPE_X86_fp80
-    | TYPE_Fp128
-    | TYPE_Ppc_fp128
+    | TYPE_Pointer None
+    | TYPE_FP _
+    | TYPE_Label
+    | TYPE_Token
     | TYPE_Metadata
     | TYPE_X86_mmx => normalized_typ_eq t_from t
-    | TYPE_Pointer subtyp =>
+    | TYPE_Pointer (Some subtyp) =>
         match t with
-        | TYPE_Pointer subtyp' =>
+        | TYPE_Pointer (Some subtyp') =>
             match flag with
             | soft => true
             | hard => normalized_typ_eq subtyp subtyp' || contains_typ subtyp t flag
@@ -1136,18 +1901,38 @@ Section ExpGenerators.
     | _ => false
     end.
 
-  Definition filter_function_pointers (typ_ctx : type_context) (ctx : var_context) : var_context :=
-    filter (fun '(_, t) => is_function_pointer typ_ctx t) ctx.
+  (* TODO: remove this *)
+  (* Definition filter_function_pointers (typ_ctx : type_context) (ctx : var_context) : var_context := *)
+  (*   filter (fun '(_, t) => is_function_pointer typ_ctx t) ctx. *)
 
   (* Can't use choose for these functions because it gets extracted to
      ocaml's Random.State.int function which has small bounds. *)
 
-  Definition gen_unsigned_bitwidth (bitwidth : N) : G Z :=
-    z <- (arbitrary : G Z);;
-    ret (Z.modulo z (2^(Z.of_N bitwidth))).
+  
+  Definition gen_int (sz : N) : G Z :=
+    let i_sz := Z.of_N sz in
+    if (i_sz <=? 8)%Z then (choose (0, 2 ^ i_sz - 1)) else ret 10000.
 
-  Definition gen_signed_bitwidth (bitwidth : N) : G Z :=
-    let zbitwidth := Z.of_N bitwidth in
+  Definition gen_int_exp (sz : N) : G (exp typ) :=
+    i_val <- gen_int sz;;
+    (ret (EXP_Integer (BinIntDef.Z.to_num_int i_val))).
+
+  Definition gen_bitZ : G Z :=
+    b <- (arbitrary : G bool);;
+    if b then ret 1 else ret 0.
+
+  Fixpoint gen_unsigned_bitwidth_h (acc : Z) (bitwidth : positive) {struct bitwidth} : G Z :=
+    if Pos.eqb bitwidth 1
+    then gen_bitZ
+    else
+      bit <- gen_bitZ;;
+      gen_unsigned_bitwidth_h (2 * acc + bit)%Z (bitwidth-1).
+
+  Definition gen_unsigned_bitwidth (bitwidth : positive) : G Z :=
+    gen_unsigned_bitwidth_h 0 bitwidth.
+
+  Definition gen_signed_bitwidth (bitwidth : positive) : G Z :=
+    let zbitwidth := Zpos bitwidth in
     let zhalf := zbitwidth - 1 in
 
     z <- (arbitrary : G Z);;
@@ -1158,25 +1943,26 @@ Section ExpGenerators.
     else
       ret (Z.modulo z (2^zhalf)).
 
-  Definition gen_gt_zero (bitwidth : option N) : G Z
+  Definition gen_gt_zero (bitwidth : option positive) : G Z
     := match bitwidth with
        | None =>
            (* Unbounded *)
-           n <- (arbitrary : G N);;
-           ret (Z.of_N (N.succ n))
+           n <- gen_unsigned_bitwidth 64;;
+           ret (1 + Z.modulo n (2^64 - 1))
        | Some bitwidth =>
-           n <- (arbitrary : G N);;
-           ret (1 + Z.modulo (Z.of_N n) (2^(Z.of_N bitwidth) - 1))
+           n <- gen_unsigned_bitwidth bitwidth;;
+           ret (1 + Z.modulo n (2^(Zpos bitwidth) - 1))
        end.
 
-  Definition gen_non_zero (bitwidth : option N) : G Z
+  Definition gen_non_zero (bitwidth : option positive) : G Z
     := match bitwidth with
        | None =>
            (* Unbounded *)
            x <- gen_gt_zero None;;
            elems_ x [x; -x]
        | Some bitwidth =>
-           let zbitwidth := Z.of_N bitwidth in
+           let zbitwidth := Zpos bitwidth in
+           let half := (bitwidth - 1)%positive in
            let zhalf := zbitwidth - 1 in
            if Z.eqb zhalf 0
            then ret (-1)
@@ -1184,109 +1970,229 @@ Section ExpGenerators.
              negative <- (arbitrary : G bool);;
              if (negative : bool)
              then
-               n <- (arbitrary : G N);;
-               ret (-(1 + Z.modulo (Z.of_N n) (2^zhalf)))
+               n <- gen_unsigned_bitwidth half;;
+               ret (-(1 + Z.modulo n (2^zhalf)))
              else
-               n <- (arbitrary : G N);;
-               ret (1 + Z.modulo (Z.of_N n) (2^zhalf - 1))
+               n <- gen_unsigned_bitwidth half;;
+               ret (1 + Z.modulo n (2^zhalf - 1))
        end.
 
-  Definition gen_non_zero_exp_size (sz : nat) (t : typ) : GenLLVM (exp typ)
-    := match t with
-       | TYPE_I n => ret EXP_Integer <*> lift (gen_non_zero (Some n))
-       | TYPE_IPTR => ret EXP_Integer <*> lift (gen_non_zero None)
-       | TYPE_Float => ret EXP_Float <*> lift fing32 (* TODO: is this actually non-zero...? *)
-       | TYPE_Double => lift failGen(*ret EXP_Double <*> lift fing64*) (*TODO : Fix generator for double*)
-       | _ => lift failGen
+  Definition gen_non_zero_exp bitwidth : G (exp typ) :=
+    i_val <- gen_non_zero bitwidth;;
+    (ret (EXP_Integer (BinIntDef.Z.to_num_int i_val))).
+
+  Definition gen_gt_zero_exp (bitwidth : option positive) : G (exp typ) :=
+    i_val <- gen_gt_zero bitwidth;;
+    (ret (EXP_Integer (BinIntDef.Z.to_num_int i_val))).
+    
+  (* Generates a random string of hex digits of length len *)
+  Fixpoint gen_hex (len : nat) : G Hexadecimal.uint :=
+    match len with
+    | 0 => ret (Hexadecimal.Nil)
+    | S n =>
+        r <- gen_hex n ;;
+        oneof
+           (ret (Hexadecimal.D0 r)) [
+            ret (Hexadecimal.D1 r) 
+          ; ret (Hexadecimal.D2 r)
+          ; ret (Hexadecimal.D3 r)                   
+          ; ret (Hexadecimal.D4 r)
+          ; ret (Hexadecimal.D5 r)                   
+          ; ret (Hexadecimal.D6 r)
+          ; ret (Hexadecimal.D7 r)                   
+          ; ret (Hexadecimal.D8 r)
+          ; ret (Hexadecimal.D9 r)                   
+          ; ret (Hexadecimal.Da r)
+          ; ret (Hexadecimal.Db r)                   
+          ; ret (Hexadecimal.Dc r)
+          ; ret (Hexadecimal.Dd r)                   
+          ; ret (Hexadecimal.De r)
+          ; ret (Hexadecimal.Df r)                   
+          ]
+    end%nat.
+
+  (* SAZ: with the new representation of floating point syntax, these could probably be done with typeclasses *)
+  Definition gen_float32_syntax : G float_syntax :=
+    h <- gen_hex 8 ;;
+    ret (FS_hex FH_X h).
+
+  Definition gen_double_syntax : G float_syntax :=
+    h <- gen_hex 16 ;;
+    ret (FS_hex FH_X h).
+  
+  Definition gen_float32_exp : G (exp typ) :=
+    ret EXP_Float <*> gen_float32_syntax.
+
+  Definition gen_double_exp : G (exp typ) :=
+    ret EXP_Float <*> gen_double_syntax.
+
+  
+  (* TODO: make this more complex using metadata *)
+  Definition gen_non_zero_exp_size (sz : nat) (t : typ) : GenLLVM (exp typ) :=
+    match t with
+       | TYPE_I n => lift (gen_non_zero_exp (Some n))
+       | TYPE_IPTR => lift (gen_non_zero_exp None)
+       | TYPE_FP FP_float => lift gen_float32_exp (* TODO: is this actually non-zero...? *)
+       | TYPE_FP FP_double => lift gen_double_exp (* TODO: is this actually non-zero...? *)
+       | _ => failGen "gen_non_zero_exp_size"
        end.
 
   Definition gen_gt_zero_exp_size (sz : nat) (t : typ) : GenLLVM (exp typ)
     := match t with
-       | TYPE_I n => ret EXP_Integer <*> lift (gen_gt_zero (Some n))
-       | TYPE_IPTR => ret EXP_Integer <*> lift (gen_gt_zero None)
-       | TYPE_Float => lift failGen
-       | TYPE_Double => lift failGen(*ret EXP_Double <*> lift fing64*) (*TODO : Fix generator for double*)
-       | _ => lift failGen
+       | TYPE_I n => lift (gen_gt_zero_exp (Some n))
+       | TYPE_IPTR => lift (gen_gt_zero_exp None)
+       | TYPE_FP FP_float => failGen "gen_gt_zero_exp_size float"
+       | TYPE_FP FP_double => failGen "gen_gt_zero_exp_size double" (*ret EXP_Double <*> lift fing64*) (*TODO : Fix generator for double*)
+       | _ => failGen "gen_gt_zero_exp_size"
        end.
 
-Definition genTypHelper (n: nat): G (typ) :=
-  run_GenLLVM (gen_typ_non_void_size n).
+  Variant exp_source :=
+    | FULL_CTX
+    | GLOBAL_CTX.
 
-Definition genType: G (typ) :=
-  sized genTypHelper.
+  (* Generate an entity to a variable *)
+  Definition gen_var_ent {a b}
+    (focus : Lens' (SystemState GenState G) (IM.Raw.t a)) (filter : GenQuery b) : GenLLVM (option Ent)
+    := focused <- use focus;;
+       gen_IntMapRaw_ent_filter focused filter.
 
-  Fixpoint gen_exp_size (sz : nat) (t : typ) {struct t} : GenLLVM (exp typ) :=
+  Definition gen_var_ident {a b}
+    (focus : Lens' (SystemState GenState G) (IM.Raw.t a)) (filter : GenQuery b) : GenLLVM (option ident)
+    := oe <- gen_var_ent focus filter;;
+       match oe with
+       | None => ret None
+       | Some e => use (gen_context' .@ entl e .@ name')
+       end.
+
+  (* Generate an entity for a variable of a given typ *)
+  (* t should already be normalized *)
+  Definition gen_var_of_typ_ent {a b}
+    (focus : Lens' (SystemState GenState G) (IM.Raw.t a))
+    (filter : GenQuery b)
+    (t : typ) : GenLLVM (option Ent)
+    := gen_var_ent focus
+         (vt <- queryl variable_type';;
+          if (normalized_typ_eq t vt)
+          then filter
+          else mzero).
+
+  (* Generate an ident for a variable of a given typ *)
+  (* t should already be normalized *)
+  Definition gen_var_of_typ_ident {a b}
+    (focus : Lens' (SystemState GenState G) (IM.Raw.t a))
+    (filter : GenQuery b)
+    (t : typ) : GenLLVM (option ident)
+    := gen_var_ident focus
+         (vt <- queryl variable_type';;
+          if (normalized_typ_eq t vt)
+          then filter
+          else mzero).
+
+  Fixpoint gen_exp_size' (gen_global_of_typ : typ -> GenLLVM (option ident)) (gen_ident_of_typ : typ -> GenLLVM (option ident)) (sz : nat) (t : typ) {struct t} : GenLLVM (exp typ) :=
     match sz with
     | 0%nat =>
-      ctx <- get_ctx;;
-      let ts := filter_type t ctx in
-      let gen_idents :=
-          match ts with
-          | [] => []
-          | _ => [(16%nat, fmap (fun '(i,_) => EXP_Ident i) (oneOf_LLVM (fmap ret ts)))]
+        (* annotate_debug ("++++++++GenExpOT: " ++ show t);; *)
+        i <- gen_ident_of_typ t;;
+        let gen_idents : list (nat * GenLLVM (exp typ)) :=
+          match i with
+          | None => []
+          | Some ident => [(320%nat, fmap (fun i => EXP_Ident i) (@ret GenLLVM _ _ ident))]
           end in
-      let fix gen_size_0 (t: typ) :=
+        let fix gen_size_0 (t: typ) :=
           match t with
           | TYPE_I n                  =>
               z <- lift (gen_unsigned_bitwidth n);;
-              ret (EXP_Integer z)
-          (* lift (x <- (arbitrary : G nat);; ret (Z.of_nat x))
-           (* TODO: should the integer be forced to be in bounds? *) *)
-          | TYPE_IPTR => ret EXP_Integer <*> lift (arbitrary : G Z)
-          | TYPE_Pointer subtyp       => lift failGen
+              ret (EXP_Integer (BinIntDef.Z.to_num_int z))
+          (* lift (x <- (arbitrary : G nat);; ret (Z.of_nat x)) *)
+          (*  (* TODO: should the integer be forced to be in bounds? *) *)
+          | TYPE_IPTR =>
+              z <- lift (arbitrary : G Z) ;;
+              ret (EXP_Integer (BinIntDef.Z.to_num_int z))
+          | TYPE_Pointer _       => failGen "gen_exp_size TYPE_Pointer"
           (* Only pointer type expressions might be conversions? Maybe GEP? *)
-          | TYPE_Void                 => lift failGen (* There should be no expressions of type void *)
-          | TYPE_Function ret args _   => lift failGen (* No expressions of function type *)
-          | TYPE_Opaque               => lift failGen (* TODO: not sure what these should be... *)
+          | TYPE_Void                 => failGen "gen_exp_size TYPE_Void" (* There should be no expressions of type void *)
+          | TYPE_Function ret args _   => failGen "gen_exp_size TYPE_Function"(* No expressions of function type *)
+          | TYPE_Opaque               => failGen "gen_exp_size TYPE_Opaque" (* TODO: not sure what these should be... *)
 
           (* Generate literals for aggregate structures *)
           | TYPE_Array n t =>
-              es <- vectorOf_LLVM (N.to_nat n) (gen_size_0 t);;
-              ret (EXP_Array (map (fun e => (t, e)) es))
+              es <- (vectorOf_LLVM (N.to_nat n) (gen_exp_size' gen_global_of_typ gen_global_of_typ 0%nat t));;
+              ret (EXP_Array (TYPE_Array n t) (map (fun e => (t, e)) es))
           | TYPE_Vector n t =>
-              es <- vectorOf_LLVM (N.to_nat n) (gen_size_0 t);;
-              ret (EXP_Vector (map (fun e => (t, e)) es))
+              es <- (vectorOf_LLVM (N.to_nat n) (gen_exp_size' gen_global_of_typ gen_global_of_typ 0%nat t));;
+              ret (EXP_Vector (TYPE_Vector n t) (map (fun e => (t, e)) es))
           | TYPE_Struct fields =>
               (* Should we divide size evenly amongst components of struct? *)
-              tes <- map_monad (fun t => e <- gen_size_0 t;; ret (t, e)) fields;;
+              tes <- map_monad (fun t => e <- (gen_exp_size' gen_global_of_typ gen_global_of_typ 0%nat t);; ret (t, e)) fields;;
               ret (EXP_Struct tes)
           | TYPE_Packed_struct fields =>
               (* Should we divide size evenly amongst components of struct? *)
-              tes <- map_monad (fun t => e <- gen_size_0 t;; ret (t, e)) fields;;
+              tes <- map_monad (fun t => e <- (gen_exp_size' gen_global_of_typ gen_global_of_typ 0%nat t);; ret (t, e)) fields;;
               ret (EXP_Packed_struct tes)
 
           | TYPE_Identified id        =>
-            ctx <- get_ctx;;
-            match find_pred (fun '(i,t) => if Ident.eq_dec id i then true else false) ctx with
-            | None => lift failGen
-            | Some (i,t) => gen_exp_size 0 t
-            end
+              t <- def_option_GenLLVM (failGen "gen_exp_size TYPE_Identified")
+                    (genFind
+                       (use (gen_context' .@ type_alias'))
+                       (n <- queryl name';;
+                        if Ident.eq_dec id n
+                        then queryl type_alias'
+                        else mzero));;
+              gen_exp_size' gen_global_of_typ gen_ident_of_typ 0%nat t
           (* Not generating these types for now *)
-          | TYPE_Half                 => lift failGen
-          | TYPE_Float                => ret EXP_Float <*> lift fing32(* referred to genarators in flocq-quickchick*)
-          | TYPE_Double               => lift failGen (*ret EXP_Double <*> lift fing64*) (* TODO: Fix generator for double*)
-          | TYPE_X86_fp80             => lift failGen
-          | TYPE_Fp128                => lift failGen
-          | TYPE_Ppc_fp128            => lift failGen
-          | TYPE_Metadata             => lift failGen
-          | TYPE_X86_mmx              => lift failGen
+          | TYPE_FP FP_float          => lift gen_float32_exp 
+          | TYPE_FP FP_double         => lift gen_double_exp 
+          | TYPE_FP _                 => failGen "gen_exp_size TYPE_FP"
+          | TYPE_Label                => failGen "gen_exp_size TYPE_Label"
+          | TYPE_Token                => failGen "gen_exp_size TYPE_Token"
+          | TYPE_Metadata             => failGen "gen_exp_size TYPE_Metadata"
+          | TYPE_X86_mmx              => failGen "gen_exp_size TYPE_X86_mmx"
           end in
-      (* Hack to avoid failing way too much *)
-      match t with
-      | TYPE_Pointer t => freq_LLVM gen_idents
-      | _ => freq_LLVM
-               (gen_idents ++ [(1%nat, gen_size_0 t)])
-      end
+        (* Hack to avoid failing way too much *)
+        match t with
+        | TYPE_Pointer (Some t) =>
+            if (seq.nilp gen_idents)
+            then
+              (* Generate Global Pointer retroactively *)
+              (* 0. Flip the global context if we are at the first level *)
+              (* 1. Generate a global id, *)
+              (* 2. recursively define the receiving types *)
+              annotate "retroactive global pointer"
+                (in_exp <- gen_exp_size' gen_global_of_typ gen_global_of_typ 0%nat t;;
+                 name <- new_global_id;;
+                 add_to_global_memo (mk_global name t false (Some in_exp) false false []);;
+                 e <- add_to_global_ctx (ID_Global name, TYPE_Pointer (Some t));;
+                 (gen_context' .@ entl e .@ deterministic') .= false;;
+                 ret (EXP_Ident (ID_Global name)))
+            else freq_LLVM (gen_idents)
+        (* TODO: handle opaque ptrs *)
+
+        (* freq_LLVM ((* (1%nat, ret EXP_Undef) :: *) gen_idents) *)
+        (* TODO: Add some retroactive global generation *)
+        | _ => freq_LLVM
+                ((10%nat, gen_size_0 t) :: (* (1%nat, ret EXP_Zero_initializer) :: *) gen_idents)
+        end
     | (S sz') =>
-      let gens :=
+        let gens :=
           match t with
           | TYPE_I isz =>
-            (* TODO: If I1 also allow ICmp and FCmp *)
-            [gen_ibinop_exp isz]
+              if Pos.eqb isz 1
+              then
+                ([ gen_ibinop_exp gen_global_of_typ gen_ident_of_typ isz
+                  ; τ <- gen_int_typ;;
+                    gen_icmp_exp_typ gen_global_of_typ gen_ident_of_typ τ
+                ] ++
+                  if enable_float_generation
+                  then
+                    [τ <- gen_float_typ;;
+                     gen_fcmp_exp_typ gen_global_of_typ gen_ident_of_typ τ
+                    ]
+                  else [])%list
+              else
+                [ gen_ibinop_exp gen_global_of_typ gen_ident_of_typ isz ]
           | TYPE_IPTR =>
-            (* TODO: If I1 also allow ICmp and FCmp *)
-            [gen_ibinop_exp_typ TYPE_IPTR]
-          | TYPE_Pointer t         => [] (* GEP? *)
+              [gen_ibinop_exp_typ gen_global_of_typ gen_ident_of_typ TYPE_IPTR]
+          | TYPE_Pointer _         => [] (* GEP? *)
 
           (* TODO: currently only generate literals for aggregate structures with size 0 exps *)
           | TYPE_Array n t => []
@@ -1294,97 +2200,154 @@ Definition genType: G (typ) :=
           | TYPE_Struct fields => []
           | TYPE_Packed_struct fields => []
 
-          | TYPE_Void              => [lift failGen] (* No void type expressions *)
-          | TYPE_Function ret args _ => [lift failGen] (* These shouldn't exist, I think *)
-          | TYPE_Opaque            => [lift failGen] (* TODO: not sure what these should be... *)
-          | TYPE_Half              => [lift failGen]
-          | TYPE_Float             => [gen_fbinop_exp TYPE_Float]
-          | TYPE_Double            => [(*gen_fbinop_exp TYPE_Double*)lift failGen]
-          | TYPE_X86_fp80          => [lift failGen]
-          | TYPE_Fp128             => [lift failGen]
-          | TYPE_Ppc_fp128         => [lift failGen]
-          | TYPE_Metadata          => [lift failGen]
-          | TYPE_X86_mmx           => [lift failGen]
+          | TYPE_Void              => [failGen "gen_exp_size TYPE_VOID list"] (* No void type expressions *)
+          | TYPE_Function ret args _ => [failGen "gen_exp_size TYPE_Function list"] (* These shouldn't exist, I think *)
+          | TYPE_Opaque            => [failGen "gen_exp_size TYPE_Opaque list"] (* TODO: not sure what these should be... *)
+          | TYPE_FP FP_float       => [gen_fbinop_exp gen_global_of_typ gen_ident_of_typ (TYPE_FP FP_float)]
+          | TYPE_FP FP_double      => [gen_fbinop_exp gen_global_of_typ gen_ident_of_typ (TYPE_FP FP_double)]
+          | TYPE_FP _              => [failGen "gen_exp_size TYPE_FP list"]
+          | TYPE_Metadata          => [failGen "gen_exp_size TYPE_Metadata list"]
+          | TYPE_Label             => [failGen "gen_exp_size TYPE_Label list"]                                       
+          | TYPE_Token             => [failGen "gen_exp_size TYPE_Token list"]
+          | TYPE_X86_mmx           => [failGen "gen_exp_size TYPE_X86_mmx list"]
           | TYPE_Identified id     =>
-            [ctx <- get_ctx;;
-             match find_pred (fun '(i,t) => if Ident.eq_dec id i then true else false) ctx with
-             | None => lift failGen
-             | Some (i,t) => gen_exp_size sz t
-             end]
+              [ t <- def_option_GenLLVM (failGen "gen_exp_size TYPE_Identified")
+                      (genFind
+                         (use (gen_context' .@ type_alias'))
+                         (n <- queryl name';;
+                          if Ident.eq_dec id n
+                          then queryl type_alias'
+                          else mzero));;
+                gen_exp_size' gen_global_of_typ gen_ident_of_typ sz t
+              ]
           end
-      in
-      (* short-circuit to size 0 *)
-      oneOf_LLVM (gen_exp_size 0 t :: gens)
+        in
+        (* short-circuit to size 0 *)
+        oneOf_LLVM (gen_exp_size' gen_global_of_typ gen_ident_of_typ 0%nat t :: gens)
     end
   with
   (* TODO: Make sure we don't divide by 0 *)
-  gen_ibinop_exp_typ (t : typ) : GenLLVM (exp typ)
-  :=
-    ibinop <- lift gen_ibinop;;
+  gen_ibinop_exp_typ (gen_global_of_typ : typ -> GenLLVM (option ident)) (gen_ident_of_typ : typ -> GenLLVM (option ident)) (t : typ) {struct t} : GenLLVM (exp typ)
+  := ibinop <- lift gen_ibinop;;
 
-    if Handlers.LLVMEvents.DV.iop_is_div ibinop && Handlers.LLVMEvents.DV.iop_is_signed ibinop
+    if AstLib.iop_is_div ibinop && AstLib.iop_is_signed ibinop
     then
-      ret (OP_IBinop ibinop) <*> ret t <*> gen_exp_size 0 t <*> gen_non_zero_exp_size 0 t
+      ret (OP_IBinop ibinop) <*> ret t <*> gen_exp_size' gen_global_of_typ gen_ident_of_typ 0%nat t <*> gen_non_zero_exp_size 0%nat t
     else
-      if Handlers.LLVMEvents.DV.iop_is_div ibinop
+      if AstLib.iop_is_div ibinop
       then
-        ret (OP_IBinop ibinop) <*> ret t <*> gen_exp_size 0 t <*> gen_gt_zero_exp_size 0 t
+        ret (OP_IBinop ibinop) <*> ret t <*> gen_exp_size' gen_global_of_typ gen_ident_of_typ 0%nat t <*> gen_gt_zero_exp_size 0%nat t
       else
-        exp_value <- gen_exp_size 0 t;;
-        if Handlers.LLVMEvents.DV.iop_is_shift ibinop
+        exp_value <- gen_exp_size' gen_global_of_typ gen_ident_of_typ 0%nat t;;
+        if AstLib.iop_is_shift ibinop
         then
           let max_shift_size :=
             match t with
-            | TYPE_I i => BinIntDef.Z.of_N (i - 1)
-            | _ => 0
+            | TYPE_I i => BinIntDef.Z.of_N (Npos i - 1)%N
+            | _ => 0%Z
             end in
-          x <- lift (choose (0, max_shift_size));;
-          let exp_value2 : exp typ := EXP_Integer x in
+          x <- lift (choose (0%Z, max_shift_size));;
+          let exp_value2 : exp typ := EXP_Integer ((BinIntDef.Z.to_num_int x)) in
           ret (OP_IBinop ibinop t exp_value exp_value2)
-        else ret (OP_IBinop ibinop t exp_value) <*> gen_exp_size 0 t
+        else ret (OP_IBinop ibinop t exp_value) <*> gen_exp_size' gen_global_of_typ gen_ident_of_typ 0%nat t
   with
-  gen_ibinop_exp (isz : N) : GenLLVM (exp typ)
+  gen_ibinop_exp (gen_global_of_typ : typ -> GenLLVM (option ident)) (gen_ident_of_typ : typ -> GenLLVM (option ident)) (isz : positive) {struct isz} : GenLLVM (exp typ)
   :=
     let t := TYPE_I isz in
-      gen_ibinop_exp_typ t
+    gen_ibinop_exp_typ gen_global_of_typ gen_ident_of_typ t
   with
-  gen_fbinop_exp (ty: typ) : GenLLVM (exp typ)
-    :=
-      match ty with
-       | TYPE_Float => fbinop <- lift gen_fbinop;;
-       if (Handlers.LLVMEvents.DV.fop_is_div fbinop)
-       then ret (OP_FBinop fbinop nil) <*> ret ty <*> gen_exp_size 0 ty <*> gen_exp_size 0 ty
-       else ret (OP_FBinop fbinop nil) <*> ret ty <*> gen_exp_size 0 ty <*> gen_exp_size 0 ty
-       | TYPE_Double => fbinop <- lift gen_fbinop;;
-       if (Handlers.LLVMEvents.DV.fop_is_div fbinop)
-       then ret (OP_FBinop fbinop nil) <*> ret ty <*> gen_exp_size 0 ty <*> gen_exp_size 0 ty
-       else ret (OP_FBinop fbinop nil) <*> ret ty <*> gen_exp_size 0 ty <*> gen_exp_size 0 ty
-       | _ => lift failGen
-      end.
+  gen_fbinop_exp (gen_global_of_typ : typ -> GenLLVM (option ident)) (gen_ident_of_typ : typ -> GenLLVM (option ident)) (ty: typ) {struct ty} : GenLLVM (exp typ)
+  :=
+    match ty with
+    | TYPE_FP FP_float => fbinop <- lift gen_fbinop;;
+                   if (AstLib.fop_is_div fbinop)
+                   then ret (OP_FBinop fbinop nil) <*> ret ty <*> gen_exp_size' gen_global_of_typ gen_ident_of_typ 0%nat ty <*> gen_exp_size' gen_global_of_typ gen_ident_of_typ 0%nat ty
+                   else ret (OP_FBinop fbinop nil) <*> ret ty <*> gen_exp_size' gen_global_of_typ gen_ident_of_typ 0%nat ty <*> gen_exp_size' gen_global_of_typ gen_ident_of_typ 0%nat ty
+    | TYPE_FP FP_double => fbinop <- lift gen_fbinop;;
+                    if (AstLib.fop_is_div fbinop)
+                    then ret (OP_FBinop fbinop nil) <*> ret ty <*> gen_exp_size' gen_global_of_typ gen_ident_of_typ 0%nat ty <*> gen_exp_size' gen_global_of_typ gen_ident_of_typ 0%nat ty
+                    else ret (OP_FBinop fbinop nil) <*> ret ty <*> gen_exp_size' gen_global_of_typ gen_ident_of_typ 0%nat ty <*> gen_exp_size' gen_global_of_typ gen_ident_of_typ 0%nat ty
+    | _ => failGen "gen_fbinop_exp"
+    end
+  with
+  gen_icmp_exp_typ (gen_global_of_typ : typ -> GenLLVM (option ident)) (gen_ident_of_typ : typ -> GenLLVM (option ident)) (t : typ) {struct t} : GenLLVM (exp typ)
+  := cmp <- lift gen_icmp;;
+     ret (OP_ICmp false cmp) <*> ret t <*> gen_exp_size' gen_global_of_typ gen_ident_of_typ 0%nat t <*> gen_non_zero_exp_size 0%nat t
+  with
+  gen_fcmp_exp_typ (gen_global_of_typ : typ -> GenLLVM (option ident)) (gen_ident_of_typ : typ -> GenLLVM (option ident)) (t : typ) {struct t} : GenLLVM (exp typ)
+  := cmp <- lift gen_fcmp;;
+     ret (OP_FCmp cmp) <*> ret t <*> gen_exp_size' gen_global_of_typ gen_ident_of_typ 0%nat t <*> gen_non_zero_exp_size 0%nat t.
 
- Definition gen_exp (t : typ) : GenLLVM (exp typ)
-    := sized_LLVM (fun sz => gen_exp_size sz t).
+  Definition gen_icmp_exp (gen_global_of_typ : typ -> GenLLVM (option ident)) (gen_ident_of_typ : typ -> GenLLVM (option ident)) : GenLLVM (exp typ)
+    := τ <- gen_int_typ;;
+       gen_icmp_exp_typ gen_global_of_typ gen_ident_of_typ τ.
+
+  Definition gen_fcmp_exp (gen_global_of_typ : typ -> GenLLVM (option ident)) (gen_ident_of_typ : typ -> GenLLVM (option ident)) : GenLLVM (exp typ)
+    := τ <- gen_float_typ;;
+       gen_fcmp_exp_typ gen_global_of_typ gen_ident_of_typ τ.
+
+  Definition gen_deterministic_global_ident :=
+    gen_var_of_typ_ident (gen_context' .@ is_global') (withl is_deterministic').
+
+  Definition gen_global_ident :=
+    gen_var_of_typ_ident (gen_context' .@ is_global') (ret tt).
+
+  Definition gen_deterministic_ident :=
+    gen_var_of_typ_ident (gen_context' .@ variable_type') (withl is_deterministic').
+
+  Definition gen_ident :=
+    gen_var_of_typ_ident (gen_context' .@ variable_type') (ret tt).
+
+  Definition gen_exp_size :=
+    gen_exp_size' gen_deterministic_global_ident.
+
+  Definition gen_exp_possibly_non_deterministic_size :=
+    gen_exp_size' gen_global_ident.
+
+  Definition gen_exp (t : typ) : GenLLVM (exp typ)
+    := annotate ("gen_exp: " ++ show t)
+         (sized_LLVM (fun sz => gen_exp_size gen_deterministic_ident sz t)).
+
+  Definition gen_exp_possibly_non_deterministic (t : typ) : GenLLVM (exp typ)
+    := annotate ("gen_exp_possibly_non_deterministic: " ++ show t)
+         (sized_LLVM (fun sz => gen_exp_possibly_non_deterministic_size gen_ident sz t)).
+
+  Definition gen_exp_sz0 (t : typ) : GenLLVM (exp typ)
+    := annotate "gen_exp_sz0" (resize_LLVM 0 (gen_exp t)).
+
+  Definition gen_exp_possibly_non_deterministic_sz0 (t : typ) : GenLLVM (exp typ)
+    := annotate "gen_exp_possibly_non_deterministic_sz0" (resize_LLVM 0 (gen_exp_possibly_non_deterministic t)).
 
   Definition gen_texp : GenLLVM (texp typ)
-    := t <- gen_typ;;
-       e <- gen_exp t;;
-       ret (t, e).
+    := annotate "gen_texp"
+         (t <- gen_typ;;
+          e <- gen_exp t;;
+          ret (t, e)).
 
   Definition gen_sized_texp : GenLLVM (texp typ)
-    := t <- gen_sized_typ;;
-       e <- gen_exp t;;
-       ret (t, e).
+    := annotate "gen_sized_texp"
+         (t <- gen_sized_typ;;
+          e <- gen_exp t;;
+          ret (t, e)).
 
   Definition gen_op (t : typ) : GenLLVM (exp typ)
     := sized_LLVM
          (fun sz =>
             match t with
             | TYPE_I isz =>
-              (* TODO: If I1 also allow ICmp and FCmp *)
-              gen_ibinop_exp isz
-            | TYPE_Float => gen_fbinop_exp TYPE_Float
-            | TYPE_Double => gen_fbinop_exp TYPE_Double
-            | _ => lift failGen
+                if Pos.eqb isz 1
+                then
+                  (* If I1 also allow ICmp and FCmp *)
+                  oneOf_LLVM
+                    [ gen_ibinop_exp gen_deterministic_global_ident gen_deterministic_ident isz
+                      ; gen_icmp_exp gen_deterministic_global_ident gen_deterministic_ident
+                      ; gen_fcmp_exp gen_deterministic_global_ident gen_deterministic_ident
+                    ]
+                else
+                  gen_ibinop_exp gen_deterministic_global_ident gen_deterministic_ident isz
+            | TYPE_FP FP_float => gen_fbinop_exp gen_deterministic_global_ident gen_deterministic_ident (TYPE_FP FP_float)
+            | TYPE_FP FP_double => gen_fbinop_exp gen_deterministic_global_ident gen_deterministic_ident (TYPE_FP FP_double)
+            | _ => failGen "gen_op"
             end).
 
   Definition gen_int_texp : GenLLVM (texp typ)
@@ -1394,16 +2357,23 @@ Definition genType: G (typ) :=
 
 End ExpGenerators.
 
+Require Import Semantics.LLVMEvents.
+Require Import Semantics.InterpretationStack.
+From ITree Require Import
+  ITree
+  Interp.Recursion
+  Events.Exception.
+
 Section InstrGenerators.
 
   (* Generator GEP part *)
   (* Get index paths from array or vector*)
   Definition get_index_paths_from_AoV (sz: N) (t: typ) (pre_path: DList Z) (sub_paths: DList (typ * DList Z)) : DList (typ * DList Z) :=
     N.recursion DList_empty
-                (fun ix acc =>
-                   let ix_sub_paths := DList_map (fun '(t, sub_path) => (t, DList_append pre_path (DList_cons (Z.of_N ix) sub_path))) sub_paths in
-                   DList_append acc ix_sub_paths)
-                sz.
+      (fun ix acc =>
+         let ix_sub_paths := DList_map (fun '(t, sub_path) => (t, DList_append pre_path (DList_cons (Z.of_N ix) sub_path))) sub_paths in
+         DList_append acc ix_sub_paths)
+      sz.
 
   (* Can work after extracting the pointer inside*)
   Fixpoint get_index_paths_aux (t_from : typ) (pre_path : DList Z) {struct t_from}: DList (typ * DList (Z)) :=
@@ -1421,7 +2391,7 @@ Section InstrGenerators.
            (fun '(ix, paths) (fld_typ : typ) =>
               (ix + 1,
                 (DList_append (get_index_paths_aux fld_typ (DList_append pre_path (DList_singleton ix)))
-                              paths)))
+                   paths)))
            fields (0%Z, DList_empty : DList (typ * DList Z))).
 
   Definition DList_paths_to_list_paths (paths : DList (typ * DList (Z))) : list (typ * list (Z))
@@ -1446,7 +2416,7 @@ Section InstrGenerators.
            (fun '(ix, paths) (fld_typ : typ) =>
               (ix + 1,
                 (DList_append (get_index_paths_agg_aux fld_typ (DList_append pre_path (DList_singleton ix)))
-                              paths)))
+                   paths)))
            fields (0%Z, DList_empty : DList (typ * DList Z))).
 
   (* The method is mainly used by extractvalue and insertvalue,
@@ -1456,161 +2426,137 @@ Section InstrGenerators.
   Definition get_index_paths_agg (t_from: typ) : list (typ * list (Z)) :=
     tl (DList_paths_to_list_paths (get_index_paths_agg_aux t_from DList_empty)).
 
-  Definition get_ctx_ptrs  : GenLLVM (list (ident * typ)) :=
-    typ_ctx <- get_typ_ctx;;
-    ctx <- get_ctx;;
-    ret (filter_ptr_typs typ_ctx ctx).
-
-  Definition get_ctx_sized_ptrs  : GenLLVM (list (ident * typ)) :=
-    typ_ctx <- get_typ_ctx;;
-    ctx <- get_ctx;;
-    ret (filter_sized_ptr_typs typ_ctx ctx).
-
   (* Index path without getting into vector *)
-  Fixpoint get_index_paths_insertvalue_aux (t_from : typ) (pre_path : DList Z) (ctx : list (ident * typ)) {struct t_from}: bool * DList (typ * DList (Z)) :=
+  (* t_from should already be normalized *)
+  Fixpoint get_index_paths_insertvalue_aux (t_from : typ) (pre_path : DList Z) {struct t_from}: GenLLVM (bool * DList (typ * DList (Z))) :=
     match t_from with
     | TYPE_Array sz t =>
-        let '(has_subpaths, sub_paths) := get_index_paths_insertvalue_aux t DList_empty ctx in (* Get index path from the first element*)
+        '(has_subpaths, sub_paths) <- get_index_paths_insertvalue_aux t DList_empty;; (* Get index path from the first element*)
         if has_subpaths
-        then (true, DList_cons (t_from, pre_path) (get_index_paths_from_AoV sz t pre_path sub_paths))
-        else (false, DList_empty)
+        then ret (true, DList_cons (t_from, pre_path) (get_index_paths_from_AoV sz t pre_path sub_paths))
+        else ret (false, DList_empty)
     | TYPE_Struct fields
     | TYPE_Packed_struct fields =>
-        let '(has_reach, reaches) := (get_index_paths_insertvalue_from_struct pre_path fields ctx) in
+        '(has_reach, reaches) <- get_index_paths_insertvalue_from_struct pre_path fields;;
         if has_reach
-        then (true, DList_cons (t_from, pre_path) reaches)
-        else (false, DList_empty)
-    | TYPE_Pointer t => if seq.nilp (filter_type t_from ctx) then (false, DList_empty) else (true, DList_singleton (t_from, pre_path))
+        then ret (true, DList_cons (t_from, pre_path) reaches)
+        else ret (false, DList_empty)
+    | TYPE_Pointer t =>
+        in_ctx <- fmap is_some (genFind
+                                 (use (gen_context' .@ variable_type'))
+                                 (nt <- queryl normalized_type';;
+                                  if (normalized_typ_eq t_from nt)
+                                  then ret tt
+                                  else mzero));;
+        if in_ctx
+        then ret (true, DList_singleton (t_from, pre_path))
+        else ret (false, DList_empty)
     | TYPE_Vector _ t =>
-        let '(has_subpaths, sub_paths) := get_index_paths_insertvalue_aux t DList_empty ctx in (* Get index path from the first element*)
-        if has_subpaths then (true, DList_singleton (t_from, pre_path)) else (false, DList_empty)
-    | _ => (true, DList_singleton (t_from, pre_path))
+        '(has_subpaths, sub_paths) <- get_index_paths_insertvalue_aux t DList_empty;; (* Get index path from the first element*)
+        if has_subpaths
+        then ret (true, DList_singleton (t_from, pre_path))
+        else ret (false, DList_empty)
+    | _ => ret (true, DList_singleton (t_from, pre_path))
     end with
-  get_index_paths_insertvalue_from_struct (pre_path: DList Z) (fields: list typ) (ctx: list (ident * typ)) {struct fields}: bool * DList (typ * DList Z) :=
-    snd (fold_left
-           (fun '(ix, (b, paths)) (fld_typ : typ) =>
-              (ix + 1,
-                (let '(has_reach, reach) := get_index_paths_insertvalue_aux fld_typ (DList_append pre_path (DList_singleton ix)) ctx in
-                 (orb has_reach b, DList_append reach paths))))
-           fields (0%Z, (false, DList_empty : DList (typ * DList Z)))).
+  get_index_paths_insertvalue_from_struct (pre_path: DList Z) (fields: list typ) {struct fields}: GenLLVM (bool * DList (typ * DList Z)) :=
+    fmap snd (fold_left
+           (fun acc (fld_typ : typ) =>
+              '(ix, (b, paths)) <- acc;;
+              '(has_reach, reach) <- get_index_paths_insertvalue_aux fld_typ (DList_append pre_path (DList_singleton ix));;
+              ret (ix + 1, (orb has_reach b, DList_append reach paths)))
+           fields (ret (0%Z, (false, DList_empty : DList (typ * DList Z))))).
 
-  Definition get_index_paths_insertvalue (t_from : typ) (ctx : list (ident * typ)): list (typ * list (Z)) :=
-    tl (DList_paths_to_list_paths (snd (get_index_paths_insertvalue_aux t_from DList_empty ctx))).
+  Definition get_index_paths_insertvalue
+    (t_from : typ)
+    : GenLLVM (list (typ * list (Z)))
+    :=
+    paths <- get_index_paths_insertvalue_aux t_from DList_empty;;
+    ret (tl (DList_paths_to_list_paths (snd paths))).
 
-  Fixpoint has_paths_insertvalue_aux (t_from : typ) (ctx : list (ident * typ)) {struct t_from}: bool :=
+  Fixpoint has_paths_insertvalue_aux (t_from : typ) {struct t_from}: GenQuery bool :=
     match t_from with
     | TYPE_Array _ t
-    | TYPE_Vector _ t => has_paths_insertvalue_aux t ctx
+    | TYPE_Vector _ t => has_paths_insertvalue_aux t
     | TYPE_Struct fields
-    | TYPE_Packed_struct fields => fold_left (fun acc x => orb acc (has_paths_insertvalue_aux x ctx)) fields false
-    | TYPE_Pointer _ => seq.nilp (filter (fun '(_, x) => normalized_typ_eq x t_from) ctx)
-    | _ => true
+    | TYPE_Packed_struct fields =>
+        fold_left (fun acc x =>
+                     cnd_rest <- acc;;
+                     cnd <- has_paths_insertvalue_aux x;;
+                     ret (orb cnd_rest cnd)) fields (ret false)
+    | TYPE_Pointer _ =>
+        (* Check for the pointer type in the context *)
+        nt <- queryl normalized_type';;
+        ret (normalized_typ_eq nt t_from)
+    | _ => ret true
     end.
 
-  Definition filter_insertvalue_typs (agg_typs : list (ident * typ)) (ctx : list (ident * typ)) : list (ident * typ) :=
-    filter (fun '(_, x) => has_paths_insertvalue_aux x ctx) agg_typs.
-
-  Definition get_ctx_ptr : GenLLVM (ident * typ) :=
-    ptrs_in_context <- get_ctx_ptrs;;
-    '(ptr_ident, ptr_typ) <- (oneOf_LLVM (map ret (ptrs_in_context)));;
-    match ptr_typ with
-    | TYPE_Pointer t => ret (ptr_ident, t)
-    | _ => lift failGen (* Should not happen *)
-    end.
-
-  Definition get_ctx_sized_ptr : GenLLVM (ident * typ) :=
-    ptrs_in_context <- get_ctx_sized_ptrs;;
-    '(ptr_ident, ptr_typ) <- (oneOf_LLVM (map ret (ptrs_in_context)));;
-    match ptr_typ with
-    | TYPE_Pointer t => ret (ptr_ident, t)
-    | _ => lift failGen (* Should not happen *)
-    end.
-
-  Definition get_ctx_agg_typs : GenLLVM (list (ident * typ)) :=
-    typ_ctx <- get_typ_ctx;;
-    ctx <- get_ctx;;
-    ret (filter_agg_typs typ_ctx ctx).
-
-  Definition get_ctx_agg_typ : GenLLVM (ident * typ) :=
-    aggs_in_context <- get_ctx_agg_typs;;
-    oneOf_LLVM (map ret aggs_in_context).
-
-  Definition get_ctx_vec_typs : GenLLVM (list (ident * typ)) :=
-    typ_ctx <- get_typ_ctx;;
-    ctx <- get_ctx;;
-    ret (filter_vec_typs typ_ctx ctx).
-
-  Definition get_ctx_vec_typ : GenLLVM (ident * typ) :=
-    vecs_in_context <- get_ctx_vec_typs;;
-    oneOf_LLVM (map ret vecs_in_context).
-
-  Definition gen_gep (tptr : typ) : GenLLVM (typ * instr typ) :=
+  Definition gen_gep (tptr : typ) : GenLLVM (instr_id * instr typ) :=
     let get_typ_in_ptr (tptr : typ) :=
       match tptr with
-      | TYPE_Pointer t => ret t
-      | _ => lift failGen
+      | TYPE_Pointer (Some t) => ret t
+      (* TODO: What about opaque pointers? *)
+      | _ => failGen "gen_gep"
       end in
-    t_in_ptr <- get_typ_in_ptr tptr;;
-    eptr <- gen_exp_size 0 tptr;;
-    let paths_in_ptr := get_index_paths_ptr t_in_ptr in (* Inner paths: Paths after removing the outer pointer *)
-    '(ret_t, path) <- oneOf_LLVM (map ret paths_in_ptr);; (* Select one path from the paths *)
-    let path_for_gep := map (fun x => (TYPE_I 32, EXP_Integer (x))) path in (* Turning the path to integer *)
-    ret (TYPE_Pointer ret_t, INSTR_Op (OP_GetElementPtr t_in_ptr (TYPE_Pointer t_in_ptr, eptr) path_for_gep)).
+    annotate "gen_gep"
+      (t_in_ptr <- get_typ_in_ptr tptr;;
+       eptr <- gen_exp_sz0 tptr;;
+       let paths_in_ptr := get_index_paths_ptr t_in_ptr in (* Inner paths: Paths after removing the outer pointer *)
+       '(ret_t, path) <- elems_LLVM paths_in_ptr;; (* Select one path from the paths *)
+       let path_for_gep := map (fun x => (TYPE_I 32, EXP_Integer ((BinIntDef.Z.to_num_int x)))) path in (* Turning the path to integer *)
+       '(id, e) <- genInstrIdEnt (TYPE_Pointer (Some ret_t));;
+       (* Default to non-deterministic for now. Need a way to look up whether the base pointer was deterministic *)
+       (gen_context' .@ entl e .@ deterministic') .= false;;
+       ret (id, INSTR_Op (OP_GetElementPtr t_in_ptr (TYPE_Pointer (Some t_in_ptr), eptr) path_for_gep))).
 
-  Definition gen_extractvalue (tagg : typ): GenLLVM (typ * instr typ) :=
-    eagg <- gen_exp_size 0 tagg;;
-    let paths_in_agg := get_index_paths_agg tagg in
-    '(t, path_for_extractvalue) <- oneOf_LLVM (map ret paths_in_agg);;
-    ret (t, INSTR_Op (OP_ExtractValue (tagg, eagg) path_for_extractvalue)).
+  Definition gen_extractvalue (tagg : typ): GenLLVM (instr_id * instr typ) :=
+    annotate ("gen_extractvalue: " ++ show tagg)
+      (eagg <- gen_exp_sz0 tagg;;
+       ntagg <- normalize_type_GenLLVM tagg;;
+       let paths_in_agg := get_index_paths_agg ntagg in
+       '(t, path_for_extractvalue) <- elems_LLVM paths_in_agg;;
+       id <- genInstrId t;;
+       ret (id, INSTR_Op (OP_ExtractValue (tagg, eagg) (List.map (BinIntDef.Z.to_num_int) path_for_extractvalue)))).
 
-  Definition gen_insertvalue (tagg: typ): GenLLVM (typ * instr typ) :=
-    eagg <- gen_exp_size 0 tagg;;
-    ctx <- get_ctx;;
-    let paths_in_agg := get_index_paths_insertvalue tagg ctx in
-    '(tsub, path_for_insertvalue) <- oneOf_LLVM (map ret paths_in_agg);;
-    esub <- hide_ctx (gen_exp_size 0 tsub);;
-    (* Generate all of the type*)
-    ret (tagg, INSTR_Op (OP_InsertValue (tagg, eagg) (tsub, esub) path_for_insertvalue)).
-
+  Definition gen_insertvalue (tagg: typ): GenLLVM (instr_id * instr typ) :=
+    annotate "gen_insertvalue"
+      (eagg <- gen_exp_sz0 tagg;;
+       ctx <- get_ctx;;
+       ntagg <- normalize_type_GenLLVM tagg;;
+       paths_in_agg <- get_index_paths_insertvalue ntagg;;
+       '(tsub, path_for_insertvalue) <- elems_LLVM paths_in_agg;;
+       (* GC: THIS IS FALSE and will cause trouble because maybe the type we want is not in the context!!! NEED TO CHANGE TO SOMETHING ELSE*)
+       esub <- hide_ctx (gen_exp_sz0 tsub);;
+       (* Generate all of the type*)
+       id <- genInstrId tagg;;
+       ret (id, INSTR_Op (OP_InsertValue (tagg, eagg) (tsub, esub) (List.map (BinIntDef.Z.to_num_int) path_for_insertvalue)))).
 
   (* ExtractElement *)
-  Definition gen_extractelement (tvec : typ): GenLLVM (typ * instr typ) :=
-    evec <- gen_exp_size 0 tvec;;
-    let get_size_ty (vType: typ) :=
-      match tvec with
-      | TYPE_Vector sz ty => (sz, ty)
-      | _ => (0%N, TYPE_Void)
-      end in
-    let '(sz, t_in_vec) := get_size_ty tvec in
-    index_for_extractelement <- lift_GenLLVM (choose (0, Z.of_N sz - 1)%Z);;
-    ret (t_in_vec, INSTR_Op (OP_ExtractElement (tvec, evec) (TYPE_I 32%N, EXP_Integer index_for_extractelement))).
+  Definition gen_extractelement (tvec : typ): GenLLVM (instr_id * instr typ) :=
+    annotate "gen_extractelement"
+      (evec <- gen_exp_sz0 tvec;;
+       let get_size_ty (vType: typ) :=
+         match tvec with
+         | TYPE_Vector sz ty => (sz, ty)
+         | _ => (0%N, TYPE_Void)
+         end in
+       let '(sz, t_in_vec) := get_size_ty tvec in
+       index_for_extractelement <- lift_GenLLVM (choose (0, Z.of_N sz - 1)%Z);;
+       id <- genInstrId t_in_vec;;
+       ret (id, INSTR_Op (OP_ExtractElement (tvec, evec) (TYPE_I 32, EXP_Integer (BinIntDef.Z.to_num_int index_for_extractelement))))).
 
-  Definition gen_insertelement (tvec : typ) : GenLLVM (typ * instr typ) :=
-    evec <- gen_exp_size 0 tvec;;
-    let get_size_ty (vType: typ) :=
-      match tvec with
-      | TYPE_Vector sz ty => (sz, ty)
-      | _ => (0%N, TYPE_Void)
-      end in
-    let '(sz, t_in_vec) := get_size_ty tvec in
-    value <- gen_exp_size 0 t_in_vec;;
-    index <- lift_GenLLVM (choose (0, Z.of_N (sz - 1)));;
-    ret (tvec, INSTR_Op (OP_InsertElement (tvec, evec) (t_in_vec, value) (TYPE_I 32, EXP_Integer index))).
-
-  Definition gen_ptrtoint (tptr : typ): GenLLVM (typ * instr typ) :=
-    eptr <- gen_exp_size 0 tptr;;
-    let gen_typ_in_ptr (tptr : typ) :=
-      match tptr with
-      | TYPE_Pointer t =>
-          gen_int_typ_for_ptr_cast (* TODO: Wait till IPTR is implemented *)
-      | TYPE_Vector sz ty =>
-          x <- gen_int_typ_for_ptr_cast;;
-          ret (TYPE_Vector sz x)
-      | _ =>
-          ret (TYPE_Void) (* Won't get into this case *)
-      end in
-    typ_from_cast <- gen_typ_in_ptr tptr;;
-    ret (typ_from_cast, INSTR_Op (OP_Conversion Ptrtoint tptr eptr typ_from_cast)).
+  Definition gen_insertelement (tvec : typ) : GenLLVM (instr_id * instr typ) :=
+    annotate "gen_insertelement"
+      (evec <- gen_exp_sz0 tvec;;
+       let get_size_ty (vType: typ) :=
+         match tvec with
+         | TYPE_Vector sz ty => (sz, ty)
+         | _ => (0%N, TYPE_Void)
+         end in
+       let '(sz, t_in_vec) := get_size_ty tvec in
+       value <- gen_exp_sz0 t_in_vec;;
+       index <- lift_GenLLVM (choose (0, Z.of_N (sz - 1)));;
+       id <- genInstrId tvec;;
+       ret (id, INSTR_Op (OP_InsertElement (tvec, evec) (t_in_vec, value) (TYPE_I 32, EXP_Integer (BinIntDef.Z.to_num_int index))))).
 
   Definition round_up_to_eight (n : N) : N :=
     if N.eqb 0 n
@@ -1619,16 +2565,19 @@ Section InstrGenerators.
 
   Fixpoint get_bit_size_from_typ (t : typ) : N :=
     match t with
-    | TYPE_I sz => N.max 1 sz
+    | TYPE_I sz => Npos sz
     | TYPE_IPTR => 64 (* TODO: probably kind of a lie... *)
     | TYPE_Pointer t => 64
     | TYPE_Void => 0
-    | TYPE_Half => 16
-    | TYPE_Float => 32
-    | TYPE_Double => 64
-    | TYPE_X86_fp80 => 80
-    | TYPE_Fp128 => 128
-    | TYPE_Ppc_fp128 => 128
+    | TYPE_FP FP_half => 16
+    | TYPE_FP FP_bfloat => 16
+    | TYPE_FP FP_float => 32                           
+    | TYPE_FP FP_double => 64
+    | TYPE_FP FP_x86_fp80 => 80
+    | TYPE_FP FP_fp128 => 128
+    | TYPE_FP FP_ppc_fp128 => 128
+    | TYPE_Label => 8
+    | TYPE_Token => 0 (* ? *)
     | TYPE_Metadata => 0
     | TYPE_X86_mmx => 64
     | TYPE_Array sz t => sz * (round_up_to_eight (get_bit_size_from_typ t))
@@ -1641,20 +2590,20 @@ Section InstrGenerators.
     | TYPE_Identified id => 0
     end.
 
-  Fixpoint get_size_from_typ (t: typ) : N :=
+  Definition get_size_from_typ (t: typ) : N :=
     round_up_to_eight (get_bit_size_from_typ t) / 8.
 
   (* Assuming max_byte_sz for this function is greater than 0 *)
   Definition get_prim_typ_le_size (max_byte_sz: N) : list (GenLLVM typ) :=
     (if (1 <=? max_byte_sz)%N then [ret (TYPE_I 1); ret (TYPE_I 8)] else []) ++
-      (if (4 <=? max_byte_sz)%N then [ret (TYPE_I 32); ret TYPE_Float] else []) ++
-      (if (8 <=? max_byte_sz)%N then [ret (TYPE_I 64); ret TYPE_Double] else []).
+      (if (4 <=? max_byte_sz)%N then [ret (TYPE_I 32); ret (TYPE_FP FP_float)] else []) ++
+      (if (8 <=? max_byte_sz)%N then [ret (TYPE_I 64) (* ; ret TYPE_Double *)] else []).
 
   (* Version without problematic i1 type *)
   Definition get_prim_vector_typ_le_size (max_byte_sz: N) : list (GenLLVM typ) :=
     (if (1 <=? max_byte_sz)%N then [ret (TYPE_I 8)] else []) ++
-      (if (4 <=? max_byte_sz)%N then [ret (TYPE_I 32); ret TYPE_Float] else []) ++
-      (if (8 <=? max_byte_sz)%N then [ret (TYPE_I 64); ret TYPE_Double] else []).
+      (if (4 <=? max_byte_sz)%N then [ret (TYPE_I 32); ret (TYPE_FP FP_float)] else []) ++
+      (if (8 <=? max_byte_sz)%N then [ret (TYPE_I 64) (* ; ret TYPE_Double *)] else []).
 
   (* Main method, it will generate based on the max_byte_sz
   Currently we support, int (1,8,32,64), float, double
@@ -1718,124 +2667,166 @@ Section InstrGenerators.
     | _ => false
     end.
 
-  Definition gen_inttoptr : GenLLVM (typ * instr typ) :=
-    ctx <- get_ptrtoint_ctx;;
-    typ_ctx <- get_typ_ctx;;
-    '(old_tptr, id, typ_from_cast) <- oneOf_LLVM (map ret ctx);;
-    (* In the following case, we will check whether there are double pointers in the old pointer type, we will not cast if the data structure has double pointer *)
-    (* TODO: Better identify the pointer inside and cast without changing their location *)
-    new_tptr <-
-      match old_tptr with
-      | TYPE_Pointer old_typ =>
-          if typ_contains_pointer old_typ || is_function_type typ_ctx old_typ
-          then
-            ret old_tptr
-          else
-            x <- gen_typ_le_size (get_size_from_typ old_typ);;
-            ret (TYPE_Pointer x)
-      | TYPE_Vector sz (TYPE_Pointer old_typ) =>
-          if typ_contains_pointer old_typ || is_function_type typ_ctx old_typ
-          then
-            ret old_tptr
-          else
-            x <- gen_typ_le_size (get_size_from_typ old_typ);;
-            ret (TYPE_Pointer x)
-      | _ => ret (TYPE_Void) (* Won't reach here... Hopefully *)
-      end;;
-    ret (new_tptr, INSTR_Op (OP_Conversion Inttoptr typ_from_cast (EXP_Ident id) new_tptr)).
+  (* Try to find a variable that's the result of a cast from a pointer *)
+  Definition gen_ptr_casted_var : GenLLVM (option Ent)
+    := gen_entity_with (gen_context' .@ from_pointer').
 
-  Definition filter_first_class_typs (ctx : var_context) : var_context :=
-    filter (fun '(_, t) =>
-              match t with
-              | TYPE_Struct _
-              | TYPE_Packed_struct _ => false
-              | TYPE_Array _ _ => false
-              | TYPE_Pointer (TYPE_Function _ _ _) => false
-              | _ => true
-              end) ctx.
+  (* Generate an identity and type for a variable that was cast from a pointer, also grab the pointer entity *)
+  Definition gen_inttoptr_info : GenLLVM (option (Ent * ident * typ))
+    := genMatch
+         (use (gen_context' .@ from_pointer'))
+         (ptr <- queryl from_pointer';;
+          t <- queryl variable_type';;
+          n <- queryl name';;
+          ret (ptr, n, t)).
 
-  Fixpoint gen_bitcast_typ (t_from : typ) : GenLLVM typ :=
+  (* TODO: old_tptr checks for vectors of pointers...
+     I don't think we will find those with the new generator queries?
+   *)
+  (* TODO: handle opaque pointers. *)
+  Definition gen_inttoptr (ptrEnt : Ent) (id : ident) (typ_from_cast : typ) : GenLLVM (instr_id * instr typ) :=
+    annotate "gen_inttoptr"
+      (opt <- use (gen_context' .@ entl ptrEnt .@ normalized_type');;
+       match opt with
+       | None => failGen "gen_inttoptr: Pointer entity missing normalized type."
+       | Some old_tptr =>
+           (* In the following case, we will check whether there are double pointers in the old pointer type, we will not cast if the data structure has double pointer *)
+           (* TODO: Better identify the pointer inside and cast without changing their location *)
+           new_tptr <-
+             match old_tptr with
+             | TYPE_Pointer (Some old_typ) =>
+                 if typ_contains_pointer old_typ || is_function_type_h old_typ
+                 then
+                   ret old_tptr
+                 else
+                   x <- gen_typ_le_size (get_size_from_typ old_typ);;
+                   ret (TYPE_Pointer (Some x))
+             | TYPE_Vector sz (TYPE_Pointer (Some old_typ)) =>
+                 if typ_contains_pointer old_typ || is_function_type_h old_typ
+                 then
+                   ret old_tptr
+                 else
+                   x <- gen_typ_le_size (get_size_from_typ old_typ);;
+                   ret (TYPE_Pointer (Some x))
+             | _ => ret (TYPE_Void) (* Won't reach here... Hopefully *)
+             end;;
+           '(iid, e) <- genInstrIdEnt new_tptr;;
+           d <- use (gen_context' .@ entl ptrEnt .@ deterministic');;
+           (* TODO: for now consider all pointers nondeterministic *)
+           (gen_context' .@ entl e .@ deterministic') .= false;;
+           ret (iid, INSTR_Op (OP_Conversion Inttoptr typ_from_cast (EXP_Ident id) new_tptr))
+       end).
+
+  (* TODO: handle opaque pointers. *)
+  Definition gen_bitcast_typ (t_from : typ) : GenLLVM typ :=
     let gen_typ_list :=
       match t_from with
       | TYPE_I 1 =>
           ret [TYPE_I 1]
       | TYPE_I 8 =>
-          ret [TYPE_I 8; TYPE_Vector 8 (TYPE_I 1)]
+          ret [TYPE_I 8 (* ; TYPE_Vector 8 (TYPE_I 1) *)]
+      | TYPE_I 16 =>
+          ret [TYPE_I 16; TYPE_Vector 2 (TYPE_I 8) (* ; TYPE_Vector 8 (TYPE_I 1) *)]
       | TYPE_I 32
-      | TYPE_Float =>
-          ret [TYPE_I 32; TYPE_Float; TYPE_Vector 4 (TYPE_I 8); TYPE_Vector 32 (TYPE_I 1)]
+      | (TYPE_FP FP_float) =>
+          ret [TYPE_I 32; TYPE_FP FP_float; TYPE_Vector 4 (TYPE_I 8); TYPE_Vector 2 (TYPE_I 16); TYPE_Vector 1 (TYPE_I 32); TYPE_Vector 1 (TYPE_FP FP_float) (* ; TYPE_Vector 32 (TYPE_I 1) *)]
       | TYPE_I 64
-      | TYPE_Double =>
-          ret [TYPE_I 64; TYPE_Double; TYPE_Vector 2 (TYPE_I 32); TYPE_Vector 2 (TYPE_Float); TYPE_Vector 8 (TYPE_I 8); TYPE_Vector 64 (TYPE_I 1)]
+      | TYPE_FP FP_double =>
+          ret [TYPE_I 64; (* TYPE_Double; *) TYPE_Vector 8 (TYPE_I 8); TYPE_Vector 4 (TYPE_I 16); TYPE_Vector 2 (TYPE_I 32); TYPE_Vector 2 (TYPE_FP FP_float) (* ; TYPE_Vector 64 (TYPE_I 1) *)]
       | TYPE_Vector sz subtyp =>
           match subtyp with
           | TYPE_Pointer _ =>
               (* TODO: Clean up. Figure out what can subtyp of pointer be *)
               (* new_subtyp <- gen_bitcast_typ subtyp;; *)
               ret [TYPE_Vector sz subtyp]
-          | subtyp =>
-              let trivial_typs := [(1%N, TYPE_I 1); (8%N, TYPE_I 8); (32%N, TYPE_I 32); (32%N, TYPE_Float); (64%N, TYPE_I 64); (64%N, TYPE_Double)] in
+          | _subtyp =>
+              let trivial_typs := [(* (1%N, TYPE_I 1); *) (8%N, TYPE_I 8); (32%N, TYPE_I 32); (32%N, TYPE_FP FP_float); (64%N, TYPE_I 64) (* ; (64%N, TYPE_Double) *)] in
               let size_of_vec := get_bit_size_from_typ t_from in
               let choices := fold_left (fun acc '(s,t) => let sz' := (size_of_vec / s)%N in
-                                                       if (sz' =? 0)%N then acc else acc ++ [TYPE_Vector sz' t])%list trivial_typs [] in
-              ret choices
+                                                       let rem := (size_of_vec mod s)%N in
+                                                       if ((sz' =? 0) || negb (rem =? 0))%N then acc else ((TYPE_Vector sz' t) :: acc)%list) trivial_typs [] in
+              ret (t_from :: choices) (* I think adding t_from here slightly biases the generator sometimes *)
           end
-      | TYPE_Pointer subtyp =>
+      | TYPE_Pointer (Some subtyp) =>
           (* TODO: Clean up. Figure out what can subtyp of pointer be *)
           (* new_subtyp <- gen_bitcast_typ subtyp;; *)
           new_subtyp <- gen_sized_typ;;
-          ret [TYPE_Pointer new_subtyp]
+          ret [TYPE_Pointer (Some new_subtyp)]
       | _ => ret [t_from] (* TODO: Add more types *) (* This currently is to prevent types like pointer of struct from failing *)
       end in
     typ_list <- gen_typ_list;;
-    oneOf_LLVM (map ret typ_list).
+    elems_LLVM typ_list.
 
   (* TODO: Another approach to form all first class types for bitcast
    If use this will get O(n^2) runtime where n is the length of the context
    but may make generating trivial types less likely to happen *)
   Fixpoint set_add_h {A} (dec : A -> A -> bool) (t : A) (prev next : list A) :=
     match next with
-    | nil => prev ++ [t]
+    | nil => (prev ++ [t])%list
     | hd::tl =>
         if dec hd t
-        then prev ++ next
+        then (prev ++ next)%list
         else set_add_h dec t (prev ++ [hd]) tl
     end%list.
 
-  Definition gen_bitcast : GenLLVM (typ * instr typ) :=
-    ctx <- get_ctx;;
-    let first_class_typs_in_ctx := filter_first_class_typs ctx in
-    trivial_typ <- oneOf_LLVM [ret (TYPE_I 1); ret (TYPE_I 8); ret (TYPE_I 32); ret (TYPE_I 64); ret (TYPE_Float); ret (TYPE_Double); ret TYPE_Vector <*> lift_GenLLVM genN <*> gen_typ_non_void_0];;
-    let gen_first_class_typs := (ret trivial_typ)::(map (fun '(_, t) => ret t) first_class_typs_in_ctx) in
-    tfc <- oneOf_LLVM gen_first_class_typs;;
-    efc <- gen_exp_size 0 tfc;;
-    new_typ <- gen_bitcast_typ tfc;;
-    ret (new_typ, INSTR_Op (OP_Conversion Bitcast tfc efc new_typ)).
+  Definition gen_trivial_typ : GenLLVM typ :=
+    oneOf_LLVM [ret (TYPE_I 1)
+                ; ret (TYPE_I 8)
+                ; ret (TYPE_I 16)
+                ; ret (TYPE_I 32)
+                ; ret (TYPE_I 64)
+                ; ret (TYPE_FP FP_float)
+                (* ; ret (TYPE_Double) *)
+                ; ret TYPE_Vector <*> lift_GenLLVM genPosN <*> gen_primitive_typ].
 
-  Definition gen_call (tfun : typ) : GenLLVM (typ * instr typ) :=
-    efun <- gen_exp_size 0 tfun;;
-    match tfun with
-    | TYPE_Pointer (TYPE_Function ret_t args varargs) =>
-        args_texp <- map_monad
-                      (fun (arg_typ:typ) =>
-                         arg_exp <- gen_exp_size 0 arg_typ;;
-                         ret (arg_typ, arg_exp))
-                      args;;
-        let args_with_params := map (fun arg => (arg, [])) args_texp in
-        ret (ret_t, INSTR_Call (TYPE_Function ret_t args varargs, efun) args_with_params [])
-    | _ => lift failGen
-    end.
+  Definition gen_first_class_typ_from_context : GenLLVM (option typ)
+    := gen_type_matching_variable (withl is_first_class_type').
 
-  (* TODO: move this *)
-  Definition genInt : G int
-    := fmap Int.repr (arbitrary : G Z).
+  Definition gen_non_aggregate_first_class_typ_from_context : GenLLVM (option typ)
+    := gen_type_matching_variable (withl is_first_class_type';; withoutl is_aggregate').
 
-  Instance GenInt : Gen int
-    := Build_Gen int genInt.
+  Definition gen_first_class_type_size : nat -> GenLLVM typ
+    := gen_typ_size' gen_trivial_typ (fun subg sz => [fun _ => subg sz]) gen_first_class_typ_from_context.
+
+  Definition gen_non_aggregate_first_class_type_size : nat -> GenLLVM typ
+    := gen_typ_size' gen_trivial_typ (fun subg sz => [fun _ => subg sz]) gen_non_aggregate_first_class_typ_from_context.
+
+  Definition gen_first_class_type : GenLLVM typ
+    := sized_LLVM (fun sz => gen_first_class_type_size (min sz max_typ_size)).
+
+  Definition gen_non_aggregate_first_class_type : GenLLVM typ
+    := sized_LLVM (fun sz => gen_non_aggregate_first_class_type_size (min sz max_typ_size)).
+
+  Definition gen_bitcast : GenLLVM (instr_id * instr typ) :=
+    annotate "gen_bitcast"
+      (tfc <- gen_trivial_typ;;
+       efc <- gen_exp_sz0 tfc;;
+       new_typ <- gen_bitcast_typ tfc;;
+       id <- genInstrId new_typ;;
+       ret (id, INSTR_Op (OP_Conversion Bitcast tfc efc new_typ))).
+
+  Definition gen_call (tfun : typ) : GenLLVM (instr_id * instr typ) :=
+    ctx <- use (gen_context' .@ @variable_type' (WorldOf _));;
+    let blah := IM.Raw.elements ctx in
+    annotate ("gen_call: " ++ show blah)
+      match tfun with
+      | TYPE_Pointer (Some (TYPE_Function ret_t args varargs)) =>
+          args_texp <- map_monad
+                        (fun (arg_typ:typ) =>
+                           arg_exp <- gen_exp_sz0 arg_typ;;
+                           ret (arg_typ, arg_exp))
+                        args;;
+          let args_with_params := map (fun arg => (arg, [])) args_texp in
+          (* Otherwise we won't find function pointers *)
+          efun <- gen_exp_possibly_non_deterministic_sz0 tfun;;
+          id <- genInstrId ret_t;;
+          ret (id, INSTR_Call (TYPE_Function ret_t args varargs, efun) args_with_params [] [])
+      | _ => failGen "gen_call"
+      end.
 
   (* TODO: move this. Also give a less confusing name because genOption is a thing? *)
   Definition gen_option {A} (g : G A) : G (option A)
-    := freq_ failGen [(1%nat, ret None); (7%nat, liftM Some g)].
+    := freq_ (ret None) [(1%nat, ret None); (7%nat, liftM Some g)].
 
   (* TODO: move these *)
   Definition opt_add_state {A} {ST} (st : ST) (o : option (A * ST)) : (option A * ST)
@@ -1844,139 +2835,219 @@ Section InstrGenerators.
        | (Some (a, st')) => (Some a, st')
        end.
 
-  Definition gen_opt_LLVM {A} (g : GenLLVM A) : GenLLVM (option A)
-    := mkStateT
-         (fun st =>
-            opt <- gen_option (runStateT g st);;
-            ret (opt_add_state st opt)).
+  (* (* TODO: move these *) *)
+  Definition either_add_state {A X} {ST} (st : ST) (o : X + (A * ST)) : ((X + A) * ST)
+    := match o with
+       | inl x => (inl x, st)
+       | inr (a, st') => (inr a, st')
+       end.
+
+  Definition opt_err_add_state {A} {ST} (st:ST) (o : option (err A * list string * ST)) : err (option A) * list string * ST :=
+    match o with
+    | None => (inr None, [], st)
+    | Some (inl msg, stack, st) => (inl msg, stack, st)
+    | Some (inr a, stack, st) => (inr (Some a), stack, st)
+    end.
 
   Definition get_typ_in_ptr (pt : typ) : GenLLVM typ :=
     match pt with
-    | TYPE_Pointer t => ret t
-    | _ => lift failGen
+    | TYPE_Pointer (Some t) => ret t
+    | _ => failGen "get_typ_in_ptr"
     end.
 
-  Definition gen_load (tptr : typ) : GenLLVM (typ * instr typ)
-    := eptr <- gen_exp_size 0 tptr;;
+  Definition gen_load (tptr : typ) : GenLLVM (instr_id * instr typ)
+    := eptr <- gen_exp_sz0 tptr;;
        vol <- lift (arbitrary : G bool);;
        ptr_typ <- get_typ_in_ptr tptr;;
        align <- ret (Some 1);;
+       id <- genInstrId ptr_typ;;
        (* TODO: Fix parameters / generate more of them *)
-       ret (ptr_typ, INSTR_Load ptr_typ (tptr, eptr) []).
+       ret (id, INSTR_Load ptr_typ (tptr, eptr) []).
 
-  Definition gen_store_to (ptr : texp typ) : GenLLVM (typ * instr typ)
+  (* TODO: handle opaque pointers?  *)
+  Definition gen_store_to (ptr : texp typ) : GenLLVM (instr_id * instr typ)
     :=
-    match ptr with
-    | (TYPE_Pointer t, pexp) =>
-        e <- resize_LLVM 0 (gen_exp t);;
-        let val := (t, e) in
+    annotate "gen_store_to"
+      match ptr with
+      | (TYPE_Pointer (Some t), pexp) =>
+          ctx <- get_ctx;;
+          e <- (gen_exp_sz0 t);;
+          let val := (t, e) in
+          id <- genVoid;;
+          ret (id, INSTR_Store val ptr [ANN_align (BinIntDef.Z.to_num_int 1)])
+      | _ => failGen "gen_store_to"
+      end.
 
-        ret (TYPE_Void, INSTR_Store val ptr [ANN_align 1])
-    | _ => lift failGen
-    end.
-
-  Definition gen_store (tptr : typ) : GenLLVM (typ * instr typ)
+  Definition gen_store (tptr : typ) : GenLLVM (instr_id * instr typ)
     :=
-    eptr <- gen_exp_size 0 tptr;;
-    ptr_typ <- get_typ_in_ptr tptr;;
-    gen_store_to(tptr, eptr).
+    annotate "gen_store"
+      (eptr <- gen_exp_sz0 tptr;;
+       ptr_typ <- get_typ_in_ptr tptr;;
+       gen_store_to(tptr, eptr)).
 
   (* Generate an instruction, as well as its type...
 
      The type is sometimes void for instructions that don't really
      compute a value, like void function calls, stores, etc.
    *)
-  Definition gen_instr : GenLLVM (typ * instr typ) :=
-    typ_ctx <- get_typ_ctx;;
-    ctx <- get_ctx;;
-    ptrtoint_ctx <- get_ptrtoint_ctx;;
-    let agg_typs_in_ctx := filter_agg_typs typ_ctx ctx in
-    let ptr_vecptr_in_ctx := filter_sized_ptr_vecptr_typs typ_ctx ctx in
-    let valid_ptr_vecptr_in_ctx := filter (fun '(_, x) => negb (contains_typ x (TYPE_Struct []) soft)) ptr_vecptr_in_ctx in
-    let sized_ptr_typs_in_ctx := filter_sized_ptr_typs typ_ctx ctx in
-    let vec_typs_in_ctx := filter_vec_typs typ_ctx ctx in
-    let fun_ptrs_in_ctx := filter_function_pointers typ_ctx ctx in
-    let insertvalue_typs_in_ctx := filter_insertvalue_typs agg_typs_in_ctx ctx in
-    let get_typ_l (ctx : var_context) : GenLLVM typ :=
-      var <- elems_LLVM ctx;;
-      ret (snd var) in
-    oneOf_LLVM
-      ([ t <- gen_op_typ;; i <- ret INSTR_Op <*> gen_op t;; ret (t, i)
-         ; t <- gen_sized_typ_ptrinctx;;
-           (* TODO: generate multiple element allocas. Will involve changing initialization *)
-           (* num_elems <- ret None;; (* gen_opt_LLVM (resize_LLVM 0 gen_int_texp);; *) *)
-           (* align <- ret None;; *)
-           ret (TYPE_Pointer t, INSTR_Alloca t [])
-        ] (* TODO: Generate atomic operations and other instructions *)
-         ++ (if seq.nilp sized_ptr_typs_in_ctx then [] else [
-                 (bind (get_typ_l sized_ptr_typs_in_ctx) gen_gep )
-                 ; bind (get_typ_l sized_ptr_typs_in_ctx) gen_load
-                 ; bind (get_typ_l sized_ptr_typs_in_ctx) gen_store])
-         ++ (if seq.nilp valid_ptr_vecptr_in_ctx then [] else [
-                 bind (get_typ_l valid_ptr_vecptr_in_ctx) gen_ptrtoint])
-         ++ (if seq.nilp ptrtoint_ctx then [] else [gen_inttoptr])
-         ++ (if seq.nilp agg_typs_in_ctx then [] else [
-                 bind (get_typ_l agg_typs_in_ctx) gen_extractvalue])
-         ++ (if seq.nilp insertvalue_typs_in_ctx then [] else [
-                 bind (get_typ_l insertvalue_typs_in_ctx) gen_insertvalue])
-         ++ (if seq.nilp vec_typs_in_ctx then [] else [
-                 bind (get_typ_l vec_typs_in_ctx) gen_extractelement
-                 ; bind (get_typ_l vec_typs_in_ctx) gen_insertelement])
-         ++ (if seq.nilp fun_ptrs_in_ctx then [] else [
-                 bind (get_typ_l fun_ptrs_in_ctx) gen_call])).
 
-  (* TODO: Generate instructions with ids *)
-  (* Make sure we can add these new ids to the context! *)
+  Definition gen_sized_ptr_type : GenLLVM (option typ)
+    := genMatch
+         (use (gen_context' .@ is_sized_pointer'))
+         (queryl variable_type').
 
-  (* TODO: want to generate phi nodes, which might be a bit
-  complicated because we need to know that an id that occurs in a
-  later block is in context *)
-  Definition add_id_to_instr (t_instr : typ * instr typ) : GenLLVM (instr_id * instr typ)
-    :=
-    match t_instr with
-    | (TYPE_Void, instr) =>
-        vid <- new_void_id;;
-        ret (vid, instr)
-    | (t, instr) =>
-        i <- new_raw_id;;
-        match instr with
-        | INSTR_Op (OP_Conversion Ptrtoint t_from v t_to) =>
-            add_to_ptrtoint_ctx (t_from, ID_Local i, t_to);; (* Register the local variable to ptrtoint_ctx*)
-            ret (IId i, instr)
-        | _ =>
-            add_to_ctx (ID_Local i, t);;
-            ret (IId i, instr)
-        end
-    end.
+  Definition gen_aggregate_type : GenLLVM (option typ)
+    := genMatch
+         (use (gen_context' .@ is_aggregate'))
+         (queryl variable_type').
 
-  (* Generate a block of code, spitting out a new context. *)
-  Definition gen_instr_id : GenLLVM (instr_id * instr typ)
-    := t_instr <- gen_instr;; add_id_to_instr t_instr.
+  Definition gen_indexable_type : GenLLVM (option typ)
+    := genMatch
+         (use (gen_context' .@ is_indexable'))
+         (queryl variable_type').
 
-  Definition fix_alloca (iid : instr_id * instr typ) : GenLLVM (list (instr_id * instr typ))
-    := match iid with
-       | (IId i, INSTR_Alloca t _) =>
-         t_instr <- gen_store_to (TYPE_Pointer t, EXP_Ident (ID_Local i));;
-         instr <- add_id_to_instr t_instr;;
-         ret [instr]
-       | _ => ret []
-       end.
+  Definition gen_ptr_vecptr_type : GenLLVM (option typ)
+    := genMatch
+         (use (gen_context' .@ is_ptr_vector'))
+         (queryl variable_type').
+
+  Definition gen_valid_ptr_vecptr_type : GenLLVM (option typ)
+    := genMatch
+         (use (gen_context' .@ is_ptr_vector'))
+         (t <- queryl variable_type';;
+          nt <- queryl normalized_type';;
+          if negb (contains_typ nt (TYPE_Struct []) soft)
+          then ret t
+          else mzero).
+
+  Definition gen_valid_ptr_vecptr_ent : GenLLVM (option (Ent * typ))
+    := genMatchEnt
+         (use (gen_context' .@ is_ptr_vector'))
+         (t <- queryl variable_type';;
+          nt <- queryl normalized_type';;
+          if negb (contains_typ nt (TYPE_Struct []) soft)
+          then ret t
+          else mzero).
+
+  Definition gen_vec_type : GenLLVM (option typ)
+    := genMatch
+         (use (gen_context' .@ is_vector'))
+         (queryl variable_type').
+
+  Definition gen_function_pointer_type : GenLLVM (option typ)
+    := genMatch
+         (use (gen_context' .@ is_function_pointer'))
+         (queryl variable_type').
+
+  Definition gen_insertvalue_type : GenLLVM (option typ)
+    := genMatch
+         (use (gen_context' .@ is_indexable'))
+         (t <- queryl variable_type';;
+          nt <- queryl normalized_type';;
+          cnd <- has_paths_insertvalue_aux nt;;
+          if cnd
+          then ret t
+          else mzero).
+
+  (* Generate a pointer to a sized type (which some variable that exists in the context already has) *)
+  Definition gen_sized_typ_in_context : GenLLVM (option typ)
+    := genMatch
+         (use (gen_context' .@ is_sized'))
+         (queryl variable_type').
+
+  Definition gen_op_instr_of_typ (τ : typ) : GenLLVM (instr_id * instr typ)
+    := i <- ret INSTR_Op <*> gen_op τ;;
+       id <- genInstrId τ;;
+       ret (id, i).
+
+  Definition gen_op_instr : GenLLVM (instr_id * instr typ)
+    := τ <- gen_op_typ;;
+       gen_op_instr_of_typ τ.
+
+  Definition gen_ptr_or_vector_ptr (τ : typ) : GenLLVM (option Ent) :=
+    gen_var_of_typ_ent (gen_context' .@ is_ptr_vector') (ret true) τ.
+
+  Definition gen_ptrtoint (ptr_ent : Ent) (tptr : typ) : GenLLVM (instr_id * instr typ) :=
+    annotate "gen_ptrtoint"
+      (let gen_typ_in_ptr (tptr : typ) :=
+         match tptr with
+         | TYPE_Pointer t =>
+             gen_int_typ_for_ptr_cast (* TODO: Wait till IPTR is implemented *)
+         | TYPE_Vector sz ty =>
+             x <- gen_int_typ_for_ptr_cast;;
+             ret (TYPE_Vector sz x)
+         | _ =>
+             ret (TYPE_Void) (* Won't get into this case *)
+         end in
+       typ_from_cast <- gen_typ_in_ptr tptr;;
+       '(id, e) <- genInstrIdEnt typ_from_cast;;
+       ptr_name <- use (gen_context' .@ entl ptr_ent .@ name');;
+       match ptr_name with
+       | None => failGen "gen_ptrtoint: unnamed pointer, shouldn't happen."
+       | Some ptr_name =>
+           let ptr_exp := EXP_Ident ptr_name in
+           (* TODO: Copy whether the pointer is deterministic *)
+           d <- use (gen_context' .@ entl ptr_ent .@ deterministic');;
+           (* Consider pointers nondeterministic for now. Currently
+              causes problems. E.g., a pointer returned from a function
+              defaults to deterministic *)
+           (gen_context' .@ entl e .@ deterministic') .= false;;
+           (gen_context' .@ entl e .@ from_pointer') .= ret ptr_ent;;
+           ret (id, INSTR_Op (OP_Conversion Ptrtoint tptr ptr_exp typ_from_cast))
+       end).
+
+  (* Generate basic instructions.
+     Note: this function returns a list because when we generate an alloca we must initialize it...
+
+     TODO: don't initialize alloca and flag it as non-deterministic?
+   *)
+  Definition gen_instr : GenLLVM (list (instr_id * instr typ)) :=
+    annotate "gen_instr"
+      (ointtoptr_info <- gen_inttoptr_info;;
+       osized_ptr_typ <- gen_sized_ptr_type;;
+       ovalid_ptr_vecptr <- gen_valid_ptr_vecptr_ent;;
+       oagg_typ <- gen_indexable_type;;
+       ovec_typ <- gen_vec_type;;
+       oinsertvalue_typ <- gen_insertvalue_type;;
+       ofun_ptr_typ <- gen_function_pointer_type;;
+       osized_typ <- gen_sized_typ_in_context;;
+       oneOf_LLVM
+         ([ op <- gen_op_instr;; t <- gen_op_typ;;
+            ret [op]
+            ; fmap ret gen_bitcast
+           ]
+            ++ (* TODO: generate multiple element allocas. Will involve changing initialization *)
+            (* num_elems <- ret None;; (* gen_opt_LLVM (resize_LLVM 0 gen_int_texp);; *) *)
+            (* align <- ret None;; *)
+            maybe [] (fun t => ['(id, e) <- genLocalEnt (TYPE_Pointer (Some t));;
+                             (* Allocas are non-deterministic *)
+                             gen_context' .@ entl e .@ deterministic' .= false;;
+                             store <- gen_store_to (TYPE_Pointer (Some t), EXP_Ident id);;
+                             ret [(IId (ident_to_raw_id id), INSTR_Alloca t []); store]]) osized_typ
+            ++ maybe [] (fun t => fmap (fun x => [x]) <$> [gen_load t; gen_store t; gen_gep t]) osized_ptr_typ
+            ++ maybe [] (fun '(e, t) => [(fun x => [x]) <$> gen_ptrtoint e t]) ovalid_ptr_vecptr
+            ++ maybe [] (fun '(e, id, t) => [(fun x => [x]) <$> gen_inttoptr e id t]) ointtoptr_info
+            ++ maybe [] (fun t => [(fun x => [x]) <$> gen_extractvalue t]) oagg_typ
+            ++ maybe [] (fun t => [(fun x => [x]) <$> gen_insertvalue t]) oinsertvalue_typ
+            ++ maybe [] (fun t => fmap (fun x => [x]) <$> [gen_extractelement t; gen_insertelement t]) ovec_typ
+            ++ maybe [] (fun t => [(fun x => [x]) <$> gen_call t]) ofun_ptr_typ
+         )).
 
   Fixpoint gen_code_length (n : nat) : GenLLVM (code typ)
     := match n with
        | O => ret []
        | S n' =>
-         instr <- gen_instr_id;;
-         (* Add an initial store if instr is alloca *)
-         alloca_store <- fix_alloca instr;;
-         rest  <- gen_code_length n';;
-         ret (instr :: alloca_store ++ rest)
+           instr <- gen_instr;;
+           rest  <- gen_code_length n';;
+           ret ((List.map (fun x => (x, [])) instr) ++ rest)%list
        end.
 
-  Definition gen_code : GenLLVM (code typ)
-    := n <- lift arbitrary;;
-       gen_code_length n.
+  Definition block_size : nat := 20.
 
+  Definition gen_code : GenLLVM (code typ)
+    := annotate "gen_code"
+         (n <- lift (resize block_size arbitrary);;
+          gen_code_length n).
 
   Definition instr_id_to_raw_id (fail_msg : string) (i : instr_id) : raw_id :=
     match i with
@@ -1987,140 +3058,156 @@ Section InstrGenerators.
   (* Returns a terminator and a list of new blocks that it reaches *)
   (* Need to make returns more likely than branches so we don't get an
      endless tree of blocks *)
+
+  Definition gen_ret (τ : typ) : GenLLVM (terminator typ)
+    := nt <- normalize_type_GenLLVM τ;;
+       match nt with
+       | TYPE_Void => ret TERM_Ret_void
+       | _ =>
+           e <- gen_exp_sz0%nat τ;;
+           ret (TERM_Ret (τ, e))
+       end.
+
   Fixpoint gen_terminator_sz
-           (sz : nat)
-           (t : typ) (* Return type *)
-           (back_blocks : list block_id) (* Blocks that I'm allowed to jump back to *)
-           {struct t} : GenLLVM (terminator typ * list (block typ))
+    (sz : nat)
+    (t : typ) (* Return type *)
+    (back_blocks : list block_id) (* Blocks that I'm allowed to jump back to *)
+    {struct t} : GenLLVM (terminator typ * list (block typ))
     :=
-      ctx <- get_ctx;;
-      match sz with
-       | 0%nat =>
-         (* Only returns allowed *)
-         match (typ_to_dtyp ctx t) with
-         | DTYPE_Void => ret (TERM_Ret_void, [])
-         | _ =>
-           e <- gen_exp_size 0 t;;
-           ret (TERM_Ret (t, e), [])
-         end
-       | S sz' =>
-         (* Need to lift oneOf to GenLLVM ...*)
-         freq_LLVM_thunked
-           ([ (6%nat, fun _ => gen_terminator_sz 0 t back_blocks)
-           (* Simple jump *)
-           ; (min sz' 6%nat, fun _ => '(b, (bh, bs)) <- gen_blocks_sz sz' t back_blocks;; ret (TERM_Br_1 (blk_id b), (bh::bs)))
-           (* Conditional branch, with no backloops *)
-           ; (min sz' 6%nat,
-               fun _ =>
-                 c <- gen_exp_size 0 (TYPE_I 1);;
+    match sz with
+    | 0%nat =>
+        term <- gen_ret t;;
+        ret (term, [])
+    | S sz' =>
+        (* Need to lift oneOf to GenLLVM ...*)
+        freq_LLVM_thunked
+          ([ (6%nat, fun _ => gen_terminator_sz 0 t back_blocks)
+               (* Simple jump *)
+             ; (min sz' 6%nat, fun _ => '(b, (bh, bs)) <- gen_blocks_sz sz' t back_blocks;; ret (TERM_Br_1 (blk_id b), (bh::bs)))
+                 (* Conditional branch, with no backloops *)
+             ; (min sz' 6%nat,
+                 fun _ =>
+                   c <- gen_exp_sz0 (TYPE_I 1);;
 
-                 (* Generate first branch *)
-                 (* We backtrack contexts so blocks in second branch
-                      don't refer to variables from the first
-                      branch. *)
-                 '(b1, (bh1, bs1)) <- backtrack_variable_ctxs (gen_blocks_sz (sz / 2) t back_blocks);;
+                   (* Generate first branch *)
+                   (* We backtrack contexts so blocks in second branch *)
+                   (* don't refer to variables from the first *)
+                   (* branch. *)
+                   '(b1, (bh1, bs1)) <- backtrack_variable_ctxs (gen_blocks_sz (sz / 2) t back_blocks);;
+                   '(b2, (bh2, bs2)) <- gen_blocks_sz (sz / 2) t back_blocks;;
 
-                 '(b2, (bh2, bs2)) <- gen_blocks_sz (sz / 2) t back_blocks;;
-
-                 ret (TERM_Br (TYPE_I 1, c) (blk_id b1) (blk_id b2), (bh1::bs1) ++ (bh2::bs2))%list)
-            (* Sometimes generate a loop *)
-            ; (min sz' 6%nat,
-                fun _ =>
-                  '(t, (b, bs)) <- gen_loop_sz sz' t back_blocks 10;; (* TODO: Should I replace sz with sz' here*)
-                  ret (t, (b :: bs)))
-           ]
-              ++
-              (* Loop back sometimes *)
-              match back_blocks with
-              | (b::bs) =>
-                  [(min sz' 1%nat,
-                     fun _ =>
-                       bid <- lift_GenLLVM (elems_ b back_blocks);;
-                       ret (TERM_Br_1 bid, []))]
-              | nil => []
-              end)
-       end
+                   ret (TERM_Br (TYPE_I 1, c) (blk_id b1) (blk_id b2), ((bh1::bs1) ++ (bh2::bs2))%list))
+                 (* Sometimes generate a loop *)
+             ; (min sz' 6%nat,
+                 fun _ =>
+                   '(t, (b, bs)) <- gen_loop_sz sz' t back_blocks 10;; (* TODO: Should I replace sz with sz' here*)
+                   ret (t, (b :: bs)))
+            ]
+             ++
+             (* Loop back sometimes *)
+             match back_blocks with
+             | (b::bs) =>
+                 [(min sz' 1%nat,
+                    fun _ =>
+                      bid <- lift_GenLLVM (elems_ b back_blocks);;
+                      ret (TERM_Br_1 bid, []))]
+             | nil => []
+             end)
+    end
   with gen_blocks_sz
          (sz : nat)
          (t : typ) (* Return type *)
          (back_blocks : list block_id) (* Blocks that I'm allowed to jump back to *)
          {struct t} : GenLLVM (block typ * (block typ * list (block typ)))
-         :=
-           bid <- new_block_id;;
-           code <- gen_code;;
-           '(term, bs) <- gen_terminator_sz (sz - 1) t back_blocks;;
-           let b := {| blk_id   := bid
-                     ; blk_phis := []
-                     ; blk_code := code
-                     ; blk_term := term
-                     ; blk_comments := None
-                    |} in
-           ret (b, (b, bs))
+       := bid <- new_block_id;;
+          (* annotate_debug ("----Genblock: " ++ show bid);; *)
+          code <- gen_code;;
+          '(term, bs) <- gen_terminator_sz (sz - 1) t back_blocks;;
+          let b := {| blk_id   := bid
+                   ;  blk_phis := []
+                   ;  blk_code := code
+                   ;  blk_term := (IVoid 0%Z, term, [])
+                   ;  blk_comments := None
+                   |} in
+          ret (b, (b, bs))
   with gen_loop_sz
          (sz : nat)
          (t : typ)
          (back_blocks : list block_id) (* Blocks that I'm allowed to jump back to *)
-         (bound : LLVMAst.int) {struct t} : GenLLVM (terminator typ * (block typ * list (block typ)))
-    :=
-      bid_entry <- new_block_id;;
-      (* TODO: make it so I can generate constant expressions *)
-      loop_init <- ret INSTR_Op <*> gen_op (TYPE_I 32 (* TODO: big ints *));; (* gen_exp_size sz (TYPE_I 64);; *)
-      bound' <- lift_GenLLVM (choose (0, bound));;
-      '(loop_init_instr_id, loop_init_instr) <- add_id_to_instr (TYPE_I 32 (* TODO: big ints *), loop_init);;
-      let loop_init_instr_raw_id := instr_id_to_raw_id "loop init id" loop_init_instr_id in
-      '(loop_cmp_id, loop_cmp) <- add_id_to_instr (TYPE_I 1, INSTR_Op (OP_ICmp Ule (TYPE_I 32 (* TODO: big ints *)) (EXP_Ident (ID_Local loop_init_instr_raw_id)) (EXP_Integer bound')));;
-      let loop_cmp_raw_id := instr_id_to_raw_id "loop_cmp_id" loop_cmp_id in
-      let lower_exp := OP_Select (TYPE_I 1, (EXP_Ident (ID_Local loop_cmp_raw_id)))
-                                 (TYPE_I 32 (* TODO: big ints *), (EXP_Ident (ID_Local loop_init_instr_raw_id)))
-                                 (TYPE_I 32 (* TODO: big ints *), EXP_Integer bound') in
-      '(select_id, select_instr) <- add_id_to_instr (TYPE_I 32 (* TODO: big ints *), INSTR_Op lower_exp);;
-      let loop_final_init_id_raw := instr_id_to_raw_id "loop iterator id" select_id in
+         (bound : LLVMAst.int_ast) {struct t} : GenLLVM (terminator typ * (block typ * list (block typ)))
+       :=
+         bid_entry <- new_block_id;;
+         (* TODO: make it so I can generate constant expressions *)
+         '(loop_init_instr_id, loop_init_instr) <- gen_op_instr_of_typ (TYPE_I 32) (* TODO: big ints *);;
+         let loop_init_instr_raw_id := instr_id_to_raw_id "loop init id" loop_init_instr_id in
+         bound' <- lift_GenLLVM (choose (0, bound));;
+         let gen_icmp (τ : typ) : GenLLVM (instr_id * instr typ) :=
+           iid <- genInstrId (TYPE_I 1);;
+           ret (iid, INSTR_Op (OP_ICmp false Ule τ (EXP_Ident (ID_Local loop_init_instr_raw_id)) (EXP_Integer (BinIntDef.Z.to_num_int bound'))))
+         in
+         '(loop_cmp_id, loop_cmp) <- gen_icmp (TYPE_I 32);; (* TODO: big ints *)
+         let loop_cmp_raw_id := instr_id_to_raw_id "loop_cmp_id" loop_cmp_id in
+         let gen_select (τ : typ) : GenLLVM (instr_id * instr typ) :=
+           let lower_exp := OP_Select (TYPE_I 1, (EXP_Ident (ID_Local loop_cmp_raw_id)))
+                              (τ, (EXP_Ident (ID_Local loop_init_instr_raw_id)))
+                              (τ, EXP_Integer (BinIntDef.Z.to_num_int bound')) in
+           iid <- genInstrId τ;;
+           ret (iid, INSTR_Op lower_exp)
+         in
+         '(select_id, select_instr) <- gen_select (TYPE_I 32);;
+         let loop_final_init_id_raw := instr_id_to_raw_id "loop iterator id" select_id in
+         '(loop_cond_id, loop_cond) <-
+           (let loop_cond_exp := INSTR_Op (OP_ICmp false Ugt (TYPE_I 32 (* TODO: big ints *)) (EXP_Ident (ID_Local loop_final_init_id_raw)) (EXP_Integer (BinIntDef.Z.to_num_int 0))) in
+           iid <- genInstrId (TYPE_I 1);;
+           ret (iid, loop_cond_exp));;
 
-      let loop_cond_exp := INSTR_Op (OP_ICmp Ugt (TYPE_I 32 (* TODO: big ints *)) (EXP_Ident (ID_Local loop_final_init_id_raw)) (EXP_Integer 0)) in
-      '(loop_cond_id, loop_cond) <- add_id_to_instr (TYPE_I 1, loop_cond_exp);;
+         let entry_code : (code typ) := [(loop_init_instr_id, loop_init_instr, []); (loop_cmp_id, loop_cmp, []); (select_id, select_instr, []); (loop_cond_id, loop_cond, [])] in
 
-      let entry_code : list (instr_id * instr typ) := [(loop_init_instr_id, loop_init_instr); (loop_cmp_id, loop_cmp); (select_id, select_instr); (loop_cond_id, loop_cond)] in
+         (* Generate end blocks *)
+         '(loop_bid, phi_id, bid_entry, bid_next, next_instr_raw_id, next_block, end_bid, end_blocks) <- backtrack_variable_ctxs
+                  ('(_, (end_b, end_bs)) <- gen_blocks_sz (sz / 2) t back_blocks;;
+                   let end_blocks := end_b :: end_bs in
+                   let end_bid := blk_id end_b in
 
-      (* Generate end blocks *)
-      ctxs <- get_variable_ctxs;;
-      '(_, (end_b, end_bs)) <- gen_blocks_sz (sz / 2) t back_blocks;;
-      let end_blocks := end_b :: end_bs in
-      let end_bid := blk_id end_b in
+                   bid_next <- new_block_id;;
+                   loop_bid <- new_block_id;;
+                   phi_id <- new_local_id;;
 
-      bid_next <- new_block_id;;
-      loop_bid <- new_block_id;;
-      phi_id <- new_raw_id;;
+                   (* Block for controlling the next iteration of the loop *)
+                   '(next_instr_id, next_instr) <-
+                     (iid <- genLocal (TYPE_I 32);;
+                      let next_exp := OP_IBinop (Sub false false) (TYPE_I 32 (* TODO: big ints *)) (EXP_Ident (ID_Local phi_id)) (EXP_Integer (BinIntDef.Z.to_num_int 1)) in
+                      ret (IId (ident_to_raw_id iid), INSTR_Op next_exp));;
+                   let next_instr_raw_id := instr_id_to_raw_id "next_exp" next_instr_id in
 
-      (* Block for controlling the next iteration of the loop *)
-      let next_exp := OP_IBinop (Sub false false) (TYPE_I 32 (* TODO: big ints *)) (EXP_Ident (ID_Local phi_id)) (EXP_Integer 1) in
-      '(next_instr_id, next_instr) <- add_id_to_instr (TYPE_I 32 (* TODO: big ints *), INSTR_Op next_exp);;
-      let next_instr_raw_id := instr_id_to_raw_id "next_exp" next_instr_id in
-      let next_cond_exp := OP_ICmp Ugt (TYPE_I 32 (* TODO: big ints *)) (EXP_Ident (ID_Local next_instr_raw_id)) (EXP_Integer 0) in
-      '(next_cond_id, next_cond) <- add_id_to_instr (TYPE_I 1, INSTR_Op next_cond_exp);;
-      let next_cond_raw_id := instr_id_to_raw_id "next_cond_exp" next_cond_id in
+                   '(next_cond_id, next_cond) <-
+                     (let next_cond_exp := OP_ICmp false Ugt (TYPE_I 32 (* TODO: big ints *)) (EXP_Ident (ID_Local next_instr_raw_id)) (EXP_Integer ((BinIntDef.Z.to_num_int 0))) in
+                      iid <- genInstrId (TYPE_I 1);;
+                      ret (iid, INSTR_Op next_cond_exp));;
+                   let next_cond_raw_id := instr_id_to_raw_id "next_cond_exp" next_cond_id in
 
-      let next_code := [(next_instr_id, next_instr); (next_cond_id, next_cond)] in
-      let next_block := {| blk_id   := bid_next
-                         ; blk_phis := []
-                         ; blk_code := next_code
-                         ; blk_term := TERM_Br (TYPE_I 1, (EXP_Ident (ID_Local next_cond_raw_id))) loop_bid end_bid
-                         ; blk_comments := None
-                         |} in
+                   let next_code : (code typ) := [(next_instr_id, next_instr, []); (next_cond_id, next_cond, [])] in
+                   let next_block := {| blk_id   := bid_next
+                                     ; blk_phis := []
+                                     ; blk_code := next_code
+                                     ; blk_term := (IVoid 0%Z, TERM_Br (TYPE_I 1, (EXP_Ident (ID_Local next_cond_raw_id))) loop_bid end_bid, [])
+                                     ; blk_comments := None
+                                     |} in
+                   ret (loop_bid, phi_id, bid_entry, bid_next, next_instr_raw_id, next_block, end_bid, end_blocks));;
 
-      (* Generate loop blocks *)
-      restore_variable_ctxs ctxs;;
-      '(loop_b, loop_bs) <- gen_loop_entry_sz (sz / 2) t loop_bid phi_id bid_entry bid_next (EXP_Ident (ID_Local loop_final_init_id_raw)) (EXP_Ident (ID_Local next_instr_raw_id)) back_blocks;;
-      let loop_blocks := loop_b :: loop_bs in
-      let loop_bid := blk_id loop_b in
+         (* Generate loop blocks *)
+         '(loop_b, loop_bs) <- gen_loop_entry_sz (sz / 2) t loop_bid phi_id bid_entry bid_next (EXP_Ident (ID_Local loop_final_init_id_raw)) (EXP_Ident (ID_Local next_instr_raw_id)) back_blocks;;
+         let loop_blocks := loop_b :: loop_bs in
+         let loop_bid := blk_id loop_b in
 
-      let entry_block := {| blk_id   := bid_entry
-                          ; blk_phis := []
-                          ; blk_code := entry_code
-                          ; blk_term := TERM_Br (TYPE_I 1, (EXP_Ident (ID_Local (instr_id_to_raw_id "loop_cond_id" loop_cond_id)))) loop_bid end_bid
-                          ; blk_comments := None
-                          |} in
+         let entry_block := {| blk_id   := bid_entry
+                            ; blk_phis := []
+                            ; blk_code := entry_code
+                            ; blk_term := (IVoid 0%Z, TERM_Br (TYPE_I 1, (EXP_Ident (ID_Local (instr_id_to_raw_id "loop_cond_id" loop_cond_id)))) loop_bid end_bid, [])
+                            ; blk_comments := None
+                            |} in
 
-      ret (TERM_Br_1 bid_entry, (entry_block, loop_blocks ++ [next_block] ++ end_blocks))%list
+         ret (TERM_Br_1 bid_entry, (entry_block, loop_blocks ++ [next_block] ++ end_blocks))%list
   with gen_loop_entry_sz
          (sz : nat)
          (t : typ)
@@ -2130,66 +3217,62 @@ Section InstrGenerators.
          (entry_exp next_exp : exp typ)
          (back_blocks : list block_id) (* Blocks that I'm allowed to jump back to *)
          {struct t} : GenLLVM (block typ * list (block typ))
-         := (* This should basically be gen_blocks_sz, but the initial block contains loop control and phi nodes *)
-           code <- gen_code;;
-           '(term, bs) <- gen_terminator_sz (sz - 1) t (bid_next::back_blocks);;
-           let b := {| blk_id   := bid_loop
-                     ; blk_phis := [(phi_id, Phi (TYPE_I 32 (* TODO: big ints *)) [(bid_entry, entry_exp); (bid_next, next_exp)])]
-                     ; blk_code := code
-                     ; blk_term := term
-                     ; blk_comments := None
-                    |} in
-           ret (b, bs).
+       := (* This should basically be gen_blocks_sz, but the initial block contains loop control and phi nodes *)
+         code <- gen_code;;
+         '(term, bs) <- gen_terminator_sz (sz - 1) t (bid_next::back_blocks);;
+         let b := {| blk_id   := bid_loop
+                  ; blk_phis := [(phi_id, Phi (TYPE_I 32 (* TODO: big ints *)) [(bid_entry, entry_exp); (bid_next, next_exp)], [])]
+                  ; blk_code := code
+                  ; blk_term := (IVoid 0%Z, term, [])
+                  ; blk_comments := None
+                  |} in
+         ret (b, bs).
 
   Definition gen_blocks (t : typ) : GenLLVM (block typ * list (block typ))
     := sized_LLVM (fun n => fmap snd (gen_blocks_sz n t [])).
 
   Definition is_main (name : global_id)
     := match name with
-       | Name sname => String.string_dec sname "main"%string
+       | Name sname => String.eqb sname "main"%string
        | Anon _
        | Raw _ => false
        end.
   (* Don't want to generate CFGs, actually. Want to generated TLEs *)
 
+  Definition gen_definition_h (name : global_id) (ret_t : typ) (args_t : list typ) : GenLLVM (definition typ (block typ * list (block typ)))
+    :=
+    (* Generate argument variables *)
+    args <- map_monad genLocal args_t;;
+    let f_type := TYPE_Function ret_t args_t false in
+    let param_attr_slots := map (fun t => []) args in
+    let prototype :=
+      mk_declaration name f_type
+        ([], param_attr_slots)
+        []
+        []
+    in
+
+    bs <- gen_blocks ret_t;;
+    ret (mk_definition (block typ * list (block typ)) prototype (map ident_to_raw_id args) bs).
+
+
   Definition gen_definition (name : global_id) (ret_t : typ) (args : list typ) : GenLLVM (definition typ (block typ * list (block typ)))
     :=
-      ctxs <- get_variable_ctxs;;
-
-      (* Add arguments to context *)
-      args <- map_monad
-               (fun t =>
-                  i <- new_raw_id;;
-                  ret (i, t))
-               args;;
-      let args_ctx := map (fun '(i, t) => (ID_Local i, t)) args in
-      append_to_ctx args_ctx;;
-
-      bs <- gen_blocks ret_t;;
-
-      let args_t := map snd args in
-      let f_type := TYPE_Function ret_t args_t false in
-      let param_attr_slots := map (fun t => []) args in
-      let prototype :=
-          mk_declaration name f_type
-                         ([], param_attr_slots)
-                         []
-                         []
-      in
-      (* Reset context *)
-      let '(ctx, ptoi_ctx) := ctxs in
-      restore_variable_ctxs ((ID_Global name, TYPE_Pointer f_type)::ctx, ptoi_ctx);;
-      ret (mk_definition (block typ * list (block typ)) prototype (map fst args) bs).
+    annotate "gen_definition"
+      (dfn <- backtrackMetadata (gen_definition_h name ret_t args);;
+       e <- add_to_global_ctx (ID_Global name, TYPE_Pointer (Some dfn.(df_prototype).(dc_type)));;
+       (gen_context' .@ entl e .@ deterministic') .= false;;
+       ret dfn).
 
   Definition gen_new_definition (ret_t : typ) (args : list typ) : GenLLVM (definition typ (block typ * list (block typ)))
     :=
-      name <- new_global_id;;
-      gen_definition name ret_t args.
+    name <- new_global_id;;
+    gen_definition name ret_t args.
 
   Definition gen_helper_function: GenLLVM (definition typ (block typ * list (block typ)))
     :=
-    ret_t <- hide_ctx gen_sized_typ_ptrinctx;;
-    args  <- listOf_LLVM (hide_ctx gen_sized_typ_ptrinctx);;
+    ret_t <- hide_ctx gen_sized_typ;;
+    args  <- listOf_LLVM (hide_ctx gen_sized_typ);;
     gen_new_definition ret_t args.
 
   Definition gen_helper_function_tle : GenLLVM (toplevel_entity typ (block typ * list (block typ)))
@@ -2204,19 +3287,38 @@ Section InstrGenerators.
   Definition gen_main_tle : GenLLVM (toplevel_entity typ (block typ * list (block typ)))
     := ret TLE_Definition <*> gen_main.
 
+  Definition gen_typ_tle : GenLLVM (toplevel_entity typ (block typ * list (block typ)))
+    :=
+    name <- new_local_id;;
+    let id := ID_Local name in
+    τ <- oneOf_LLVM_thunked
+          [ (fun _ => ret TYPE_Struct <*> (k <- lift (choose (0, 5)%nat);;
+                                        vectorOf_LLVM k gen_typ_non_void_wo_fn))
+            ; (fun _ => ret TYPE_Packed_struct <*> (k <- lift (choose (0, 5)%nat);;
+                                        vectorOf_LLVM k gen_typ_non_void_wo_fn))
+          ];;
+    add_to_typ_ctx (id, τ);;
+    ret (TLE_Type_decl id τ).
+
+  Definition gen_typ_tle_multiple : GenLLVM (list (toplevel_entity typ (block typ * list (block typ))))
+    := listOf_LLVM gen_typ_tle.
+
   Definition gen_global_var : GenLLVM (global typ)
     :=
-      name <- new_global_id;;
-      t <- hide_ctx gen_sized_typ_ptrinctx;;
-      opt_exp <- fmap Some (hide_ctx (gen_exp_size 0 t));;
-      add_to_ctx (ID_Global name, TYPE_Pointer t);;
-      let ann_linkage : list (annotation typ) :=
-        match opt_exp with
-        | None => [ANN_linkage (LINKAGE_External)]
-        | Some _ => []
-        end in
-      let annotations := ann_linkage in (* TODO: Add more flags *)
-      ret (mk_global name t false opt_exp false annotations).
+    name <- new_global_id;;
+    t <- hide_ctx gen_sized_typ;;
+    (* annotate_debug ("--Generate: Global: @" ++ show name ++ " " ++ show t);; *)
+    opt_exp <- fmap Some (hide_ctx (gen_exp_sz0 t));;
+    e <- add_to_global_ctx (ID_Global name, TYPE_Pointer (Some t));;
+    (gen_context' .@ entl e .@ deterministic') .= false;;
+    let ann_linkage : list (annotation typ) :=
+      match opt_exp with
+      | None => [ANN_linkage (LINKAGE_External)]
+      | Some _ => []
+      end in
+    let annotations := ann_linkage in (* TODO: Add more flags *)
+
+    ret (mk_global name t false opt_exp false false annotations).
 
   Definition gen_global_tle : GenLLVM (toplevel_entity typ (block typ * list (block typ)))
     := ret TLE_Global <*> gen_global_var.
@@ -2224,11 +3326,25 @@ Section InstrGenerators.
   Definition gen_global_tle_multiple : GenLLVM (list (toplevel_entity typ (block typ * list (block typ))))
     := listOf_LLVM  gen_global_tle.
 
+  Definition list_high_level_dec : list (declaration typ) :=
+    [
+      let puts_id := Name "puts" in
+      let puts_typ := TYPE_Function (TYPE_I 32) [(TYPE_Pointer (Some (TYPE_I 8)))] false in
+      mk_declaration puts_id puts_typ ([], []) [] []
+    ].
+
+  Definition gen_list_high_level_tle : GenLLVM (list (toplevel_entity typ (block typ * list (block typ)))) :=
+    ret (map TLE_Declaration list_high_level_dec).
+
   Definition gen_llvm : GenLLVM (list (toplevel_entity typ (block typ * list (block typ))))
     :=
+    high_levels <- gen_list_high_level_tle;;
+    defined_typs <- gen_typ_tle_multiple;;
     globals <- gen_global_tle_multiple;;
     functions <- gen_helper_function_tle_multiple;;
     main <- gen_main_tle;;
-    ret (globals ++ functions ++ [main])%list.
+    res_globals <- get_global_memo;;
+    let new_globals := (globals ++ map TLE_Global res_globals)%list in
+    ret (high_levels ++ defined_typs ++ new_globals ++ functions ++ [main])%list.
 
 End InstrGenerators.

--- a/src/rocq/GenAST.v
+++ b/src/rocq/GenAST.v
@@ -37,7 +37,8 @@ From GenLLVM Require Import
   GenMetadata.
 
 
-Require Import Integers.
+Require Import Integers Floats.
+From Flocq Require Import IEEE754.Bits.
 
 
 From ExtLib.Structures Require Export
@@ -2012,10 +2013,41 @@ Section ExpGenerators.
           ]
     end%nat.
 
+  Definition hex_digit_of_Z (z: Z) : Hexadecimal.uint -> Hexadecimal.uint :=
+    match Z.to_nat z with
+    | 0%nat => Hexadecimal.D0
+    | 1%nat => Hexadecimal.D1
+    | 2%nat => Hexadecimal.D2
+    | 3%nat => Hexadecimal.D3
+    | 4%nat => Hexadecimal.D4
+    | 5%nat => Hexadecimal.D5
+    | 6%nat => Hexadecimal.D6
+    | 7%nat => Hexadecimal.D7
+    | 8%nat => Hexadecimal.D8
+    | 9%nat => Hexadecimal.D9
+    | 10%nat => Hexadecimal.Da
+    | 11%nat => Hexadecimal.Db
+    | 12%nat => Hexadecimal.Dc
+    | 13%nat => Hexadecimal.Dd
+    | 14%nat => Hexadecimal.De
+    | _ => Hexadecimal.Df
+    end.
+
+  Fixpoint hex_of_Z_fuel (f: nat) (z: Z) (acc: Hexadecimal.uint) : Hexadecimal.uint :=
+    match f with
+    | O => acc
+    | S f' => hex_of_Z_fuel f' (z / 16) (hex_digit_of_Z (z mod 16) acc)
+    end.
+
+  Definition hex64_of_Z (z: Z) : Hexadecimal.uint :=
+    hex_of_Z_fuel 16 z Hexadecimal.Nil.
+
   (* SAZ: with the new representation of floating point syntax, these could probably be done with typeclasses *)
   Definition gen_float32_syntax : G float_syntax :=
     h <- gen_hex 8 ;;
-    ret (FS_hex FH_X h).
+    let z32 := BinInt.Z.of_hex_uint h in
+    let d32 := (hex64_of_Z (Bits.bits_of_b64 (Floats.Float32.to_double (Bits.b32_of_bits z32)))) in
+    ret (FS_hex FH_X d32).
 
   Definition gen_double_syntax : G float_syntax :=
     h <- gen_hex 16 ;;

--- a/src/rocq/GenAST.v
+++ b/src/rocq/GenAST.v
@@ -13,7 +13,6 @@
 
 From Vellvm.Syntax Require Import
   CFG
-  TypeUtil
   TypToDtyp
   DynamicTypes.
 
@@ -22,14 +21,15 @@ From Vellvm.Semantics Require Import
 
 From Vellvm Require Import
   LLVMAst
-  Utilities
+  Utils
   AstLib
   DynamicTypes
-  DList
-  IntMaps
-  Utils.Default.
+  Utils.DList
+  IntMaps.
 
-From Vellvm.QC Require Import
+From GenLLVM Require Import
+  Default
+  TypeUtil
   Utils
   Generators
   ECS
@@ -78,6 +78,7 @@ Open Scope string.
     not used in proofs) it's not terribly important to prove that they
     actually terminate.  *)
 Unset Guard Checking.
+Unset Implicit Arguments.
 
 (* Controls whether or not we generate floats... The float generators
 often break with updates, so this may be convenient *)
@@ -94,7 +95,7 @@ Section Helpers.
   Fixpoint is_sized_type_h (t : typ) : bool
     := match t with
        | TYPE_I sz => true
-       | TYPE_IPTR => true
+       | TYPE_Iptr => true
        | TYPE_Pointer (Some t) => is_sized_type_h t
        | TYPE_Pointer None => true
        | TYPE_Void => false
@@ -966,7 +967,7 @@ Section TypGenerators.
             ret (TYPE_Identified id)
         end
     | TYPE_I sz => ret t
-    | TYPE_IPTR => ret t
+    | TYPE_Iptr => ret t
     | TYPE_Pointer (Some t') =>
         pt <- normalize_type_GenLLVM t';;
         ret (TYPE_Pointer (Some pt))
@@ -1714,9 +1715,9 @@ Section ExpGenerators.
          | TYPE_I sz' => if Pos.eq_dec sz sz' then true else false
          | _ => false
          end
-       | TYPE_IPTR =>
+       | TYPE_Iptr =>
          match b with
-         | TYPE_IPTR => true
+         | TYPE_Iptr => true
          | _ => false
          end
        | TYPE_Pointer t =>
@@ -1837,7 +1838,7 @@ Section ExpGenerators.
             end
         | _ => false
         end
-    | TYPE_IPTR
+    | TYPE_Iptr
     | TYPE_Pointer None
     | TYPE_FP _
     | TYPE_Label
@@ -2031,7 +2032,7 @@ Section ExpGenerators.
   Definition gen_non_zero_exp_size (sz : nat) (t : typ) : GenLLVM (exp typ) :=
     match t with
        | TYPE_I n => lift (gen_non_zero_exp (Some n))
-       | TYPE_IPTR => lift (gen_non_zero_exp None)
+       | TYPE_Iptr => lift (gen_non_zero_exp None)
        | TYPE_FP FP_float => lift gen_float32_exp (* TODO: is this actually non-zero...? *)
        | TYPE_FP FP_double => lift gen_double_exp (* TODO: is this actually non-zero...? *)
        | _ => failGen "gen_non_zero_exp_size"
@@ -2040,7 +2041,7 @@ Section ExpGenerators.
   Definition gen_gt_zero_exp_size (sz : nat) (t : typ) : GenLLVM (exp typ)
     := match t with
        | TYPE_I n => lift (gen_gt_zero_exp (Some n))
-       | TYPE_IPTR => lift (gen_gt_zero_exp None)
+       | TYPE_Iptr => lift (gen_gt_zero_exp None)
        | TYPE_FP FP_float => failGen "gen_gt_zero_exp_size float"
        | TYPE_FP FP_double => failGen "gen_gt_zero_exp_size double" (*ret EXP_Double <*> lift fing64*) (*TODO : Fix generator for double*)
        | _ => failGen "gen_gt_zero_exp_size"
@@ -2105,7 +2106,7 @@ Section ExpGenerators.
               ret (EXP_Integer (BinIntDef.Z.to_num_int z))
           (* lift (x <- (arbitrary : G nat);; ret (Z.of_nat x)) *)
           (*  (* TODO: should the integer be forced to be in bounds? *) *)
-          | TYPE_IPTR =>
+          | TYPE_Iptr =>
               z <- lift (arbitrary : G Z) ;;
               ret (EXP_Integer (BinIntDef.Z.to_num_int z))
           | TYPE_Pointer _       => failGen "gen_exp_size TYPE_Pointer"
@@ -2190,8 +2191,8 @@ Section ExpGenerators.
                   else [])%list
               else
                 [ gen_ibinop_exp gen_global_of_typ gen_ident_of_typ isz ]
-          | TYPE_IPTR =>
-              [gen_ibinop_exp_typ gen_global_of_typ gen_ident_of_typ TYPE_IPTR]
+          | TYPE_Iptr =>
+              [gen_ibinop_exp_typ gen_global_of_typ gen_ident_of_typ TYPE_Iptr]
           | TYPE_Pointer _         => [] (* GEP? *)
 
           (* TODO: currently only generate literals for aggregate structures with size 0 exps *)
@@ -2566,7 +2567,7 @@ Section InstrGenerators.
   Fixpoint get_bit_size_from_typ (t : typ) : N :=
     match t with
     | TYPE_I sz => Npos sz
-    | TYPE_IPTR => 64 (* TODO: probably kind of a lie... *)
+    | TYPE_Iptr => 64 (* TODO: probably kind of a lie... *)
     | TYPE_Pointer t => 64
     | TYPE_Void => 0
     | TYPE_FP FP_half => 16
@@ -2714,7 +2715,7 @@ Section InstrGenerators.
            d <- use (gen_context' .@ entl ptrEnt .@ deterministic');;
            (* TODO: for now consider all pointers nondeterministic *)
            (gen_context' .@ entl e .@ deterministic') .= false;;
-           ret (iid, INSTR_Op (OP_Conversion Inttoptr typ_from_cast (EXP_Ident id) new_tptr))
+           ret (iid, INSTR_Op (OP_Conversion (CONV_Impure Inttoptr) typ_from_cast (EXP_Ident id) new_tptr))
        end).
 
   (* TODO: handle opaque pointers. *)
@@ -2803,7 +2804,7 @@ Section InstrGenerators.
        efc <- gen_exp_sz0 tfc;;
        new_typ <- gen_bitcast_typ tfc;;
        id <- genInstrId new_typ;;
-       ret (id, INSTR_Op (OP_Conversion Bitcast tfc efc new_typ))).
+       ret (id, INSTR_Op (OP_Conversion CONV_Bitcast tfc efc new_typ))).
 
   Definition gen_call (tfun : typ) : GenLLVM (instr_id * instr typ) :=
     ctx <- use (gen_context' .@ @variable_type' (WorldOf _));;
@@ -2993,7 +2994,7 @@ Section InstrGenerators.
               defaults to deterministic *)
            (gen_context' .@ entl e .@ deterministic') .= false;;
            (gen_context' .@ entl e .@ from_pointer') .= ret ptr_ent;;
-           ret (id, INSTR_Op (OP_Conversion Ptrtoint tptr ptr_exp typ_from_cast))
+           ret (id, INSTR_Op (OP_Conversion (CONV_Impure Ptrtoint) tptr ptr_exp typ_from_cast))
        end).
 
   (* Generate basic instructions.
@@ -3253,7 +3254,7 @@ Section InstrGenerators.
     in
 
     bs <- gen_blocks ret_t;;
-    ret (mk_definition (block typ * list (block typ)) prototype (map ident_to_raw_id args) bs).
+    ret (mk_definition prototype (map ident_to_raw_id args) bs).
 
 
   Definition gen_definition (name : global_id) (ret_t : typ) (args : list typ) : GenLLVM (definition typ (block typ * list (block typ)))

--- a/src/rocq/GenMetadata.v
+++ b/src/rocq/GenMetadata.v
@@ -1,0 +1,1108 @@
+From Ltac2 Require Import Ltac2.
+From Stdlib Require Import List String.
+From Vellvm.Utils Require Import
+  IntMaps
+  Monads
+  Default.
+
+From Vellvm.Syntax Require Import
+  LLVMAst.
+
+From Vellvm.QC Require Import ECS Lens.
+Import LensNotations.
+Local Open Scope lens.
+
+Require Import ExtLib.Data.Monads.StateMonad.
+Require Import ExtLib.Data.Monads.OptionMonad.
+Require Import ExtLib.Data.Monads.ReaderMonad.
+Require Import ExtLib.Structures.Monads.
+Require Import ExtLib.Structures.Functor.
+Require Import ExtLib.Structures.Applicative.
+Require Import ExtLib.Structures.Traversable.
+Require Import ExtLib.Structures.Foldable.
+Require Import ExtLib.Structures.MonadPlus.
+Import MonadNotation.
+Import MonadPlusNotation.
+Import ApplicativeNotation.
+Import FunctorNotation.
+Import ListNotations.
+
+Record Metadata s :=
+  mkMetadata
+    { name : Component s Field ident
+    ; type_alias : Component s Field typ
+    ; variable_type : Component s Field typ
+    ; normalized_type : Component s Field typ
+    ; is_local : Component s Field unit
+    ; is_global : Component s Field unit
+    ; is_deterministic : Component s Field unit
+    ; is_non_deterministic : Component s Field unit
+    (* Whether the variable is the result of a pointer cast *)
+    ; from_pointer : Component s Field Ent
+    (* Whether the variable has a pointer type *)
+    ; is_pointer : Component s Field unit
+    (* Whether the variable is a pointer to sized type *)
+    ; is_sized_pointer : Component s Field unit
+    (* Whether the variable is of a sized type *)
+    ; is_sized : Component s Field unit
+    (* Whether the variable is an aggregate type *)
+    ; is_aggregate : Component s Field unit
+    (* Whether the variable is an aggregate type with values (e.g., not an array of 0 elements) *)
+    ; is_indexable : Component s Field unit
+    (* Whether the variable is a vector type *)
+    ; is_vector : Component s Field unit
+    (* Whether the variable is an array type *)
+    ; is_array : Component s Field unit
+    (* Whether the variable is a structure type *)
+    ; is_struct : Component s Field unit
+    (* Whether the variable is a void type *)
+    ; is_non_void : Component s Field unit
+    (* Whether the variable is a pointer type or a vector of pointers *)
+    ; is_ptr_vector : Component s Field unit
+    (* Whether the variable is a pointer type or a vector of pointers to sized types *)
+    ; is_sized_ptr_vector : Component s Field unit
+    (* Whether a type alias is to a sized type *)
+    ; is_sized_type_alias : Component s Field unit
+    (* Whether a variable / type alias has a first class type *)
+    ; is_first_class_type : Component s Field unit
+    (* Whether a variable / type alias has a function pointer type *)
+    ; is_function_pointer : Component s Field unit
+    }.
+
+Definition blankSetter : (Metadata SetterOf).
+  constructor.
+  all: apply Keep.
+Defined.
+
+Definition defFields : (Metadata FieldOf).
+  constructor.
+  all: apply None.
+Defined.
+
+#[global] Instance Default_Metadata {s} : Default (Metadata s).
+split.
+destruct s.
+- apply defFields.
+- apply mkMetadata; apply IM.empty.
+- apply blankSetter.
+Defined.
+
+Ltac2 metadataConstructors :=
+  [ (fun _ => apply name)
+  ; (fun _ => apply type_alias)
+  ; (fun _ => apply variable_type)
+  ; (fun _ => apply normalized_type)
+  ; (fun _ => apply is_local)
+  ; (fun _ => apply is_global)
+  ; (fun _ => apply is_deterministic)
+  ; (fun _ => apply is_non_deterministic)
+  ; (fun _ => apply from_pointer)
+  ; (fun _ => apply is_pointer)
+  ; (fun _ => apply is_sized_pointer)
+  ; (fun _ => apply is_sized)
+  ; (fun _ => apply is_aggregate)
+  ; (fun _ => apply is_indexable)
+  ; (fun _ => apply is_vector)
+  ; (fun _ => apply is_array)
+  ; (fun _ => apply is_struct)
+  ; (fun _ => apply is_non_void)
+  ; (fun _ => apply is_ptr_vector)
+  ; (fun _ => apply is_sized_ptr_vector)
+  ; (fun _ => apply is_sized_type_alias)
+  ; (fun _ => apply is_first_class_type)
+  ; (fun _ => apply is_function_pointer)
+  ].
+
+Ltac2 applyMetadataConstructors (tac : unit -> unit) :=
+  Control.dispatch
+    [ (fun _ => tac (); apply name)
+      ; (fun _ => tac (); apply type_alias)
+      ; (fun _ => tac (); apply variable_type)
+      ; (fun _ => tac (); apply normalized_type)
+      ; (fun _ => tac (); apply is_local)
+      ; (fun _ => tac (); apply is_global)
+      ; (fun _ => tac (); apply is_deterministic)
+      ; (fun _ => tac (); apply is_non_deterministic)
+      ; (fun _ => tac (); apply from_pointer)
+      ; (fun _ => tac (); apply is_pointer)
+      ; (fun _ => tac (); apply is_sized_pointer)
+      ; (fun _ => tac (); apply is_sized)
+      ; (fun _ => tac (); apply is_aggregate)
+      ; (fun _ => tac (); apply is_indexable)
+      ; (fun _ => tac (); apply is_vector)
+      ; (fun _ => tac (); apply is_array)
+      ; (fun _ => tac (); apply is_struct)
+      ; (fun _ => tac (); apply is_non_void)
+      ; (fun _ => tac (); apply is_ptr_vector)
+      ; (fun _ => tac (); apply is_sized_ptr_vector)
+      ; (fun _ => tac (); apply is_sized_type_alias)
+      ; (fun _ => tac (); apply is_first_class_type)
+      ; (fun _ => tac (); apply is_function_pointer)
+    ].
+
+Definition getEntity {w m} `{Monad m} `{@MetadataStore m Metadata (SystemState w m)}
+  (entity : Ent) : SystemT w m (Metadata FieldOf).
+  refine open_constr:(let entity_id := unEnt entity in
+                      storage <- use metadata;;
+                      ret (_)); try typeclasses_eauto.
+  apply (mkMetadata FieldOf);
+    refine open_constr:(IM.Raw.find entity_id (_ storage));
+    Control.dispatch metadataConstructors.
+Defined.
+
+Definition setterOfFields (vals : Metadata FieldOf) : Metadata SetterOf.
+  constructor;
+    applyMetadataConstructors (fun _ => refine open_constr:(optionToUpdate (_ vals))).
+Defined.
+
+Definition setEntity
+  {w m} `{Monad m} `{@MetadataStore m Metadata (SystemState w m)}
+  (entity : Ent) (setter : Metadata SetterOf) : SystemT w m unit.
+  refine
+    open_constr:(let entity_id := unEnt entity in
+                 metadata _ _ %= (fun storage => _);;
+                 entities %= (fun ents => IS.add entity_id ents);;
+                 ret tt);
+    try typeclasses_eauto.
+  apply (mkMetadata (WorldOf m));
+    applyMetadataConstructors (fun _ => refine open_constr:(updateIntMapRaw (_ setter) entity_id (_ storage))).
+Defined.
+
+Definition setEntities
+  {w : StorageType -> Type} {m : Type -> Type}
+  `{Monad m} `{@MetadataStore m Metadata (SystemState w m)}
+  (es : IM.Raw.t (Metadata FieldOf)) : SystemT w m unit
+  := IM.Raw.fold (fun k fs acc => setEntity (mkEnt k) (setterOfFields fs);; acc) es (ret tt).
+
+Definition name' {s : StorageType} : Lens' (Metadata s) (Component s Field ident).
+  red.
+  intros f F afa w.
+  refine open_constr:((fun x => _) <$> afa (_ w)); try typeclasses_eauto.
+  - apply mkMetadata;
+      Control.dispatch
+        [ (fun _ => apply x)
+          ; (fun _ => apply type_alias)
+          ; (fun _ => apply variable_type)
+          ; (fun _ => apply normalized_type)
+          ; (fun _ => apply is_local)
+          ; (fun _ => apply is_global)
+          ; (fun _ => apply is_deterministic)
+          ; (fun _ => apply is_non_deterministic)
+          ; (fun _ => apply from_pointer)
+          ; (fun _ => apply is_pointer)
+          ; (fun _ => apply is_sized_pointer)
+          ; (fun _ => apply is_sized)
+          ; (fun _ => apply is_aggregate)
+          ; (fun _ => apply is_indexable)
+          ; (fun _ => apply is_vector)
+          ; (fun _ => apply is_array)
+          ; (fun _ => apply is_struct)
+          ; (fun _ => apply is_non_void)
+          ; (fun _ => apply is_ptr_vector)
+          ; (fun _ => apply is_sized_ptr_vector)
+          ; (fun _ => apply is_sized_type_alias)
+          ; (fun _ => apply is_first_class_type)
+          ; (fun _ => apply is_function_pointer)
+        ];
+      apply w.
+  - apply name.
+Defined.
+
+Definition is_global' {s : StorageType} : Lens' (Metadata s) (Component s Field unit).
+  red.
+  intros f F afa w.
+  refine open_constr:((fun x => _) <$> afa (_ w)); try typeclasses_eauto.
+  - apply mkMetadata;
+      Control.dispatch
+        [ (fun _ => apply name)
+          ; (fun _ => apply type_alias)
+          ; (fun _ => apply variable_type)
+          ; (fun _ => apply normalized_type)
+          ; (fun _ => apply is_local)
+          ; (fun _ => apply x)
+          ; (fun _ => apply is_deterministic)
+          ; (fun _ => apply is_non_deterministic)
+          ; (fun _ => apply from_pointer)
+          ; (fun _ => apply is_pointer)
+          ; (fun _ => apply is_sized_pointer)
+          ; (fun _ => apply is_sized)
+          ; (fun _ => apply is_aggregate)
+          ; (fun _ => apply is_indexable)
+          ; (fun _ => apply is_vector)
+          ; (fun _ => apply is_array)
+          ; (fun _ => apply is_struct)
+          ; (fun _ => apply is_non_void)
+          ; (fun _ => apply is_ptr_vector)
+          ; (fun _ => apply is_sized_ptr_vector)
+          ; (fun _ => apply is_sized_type_alias)
+          ; (fun _ => apply is_first_class_type)
+          ; (fun _ => apply is_function_pointer)
+        ];
+      apply w.
+  - apply is_global.
+Defined.
+
+Definition is_local' {s : StorageType} : Lens' (Metadata s) (Component s Field unit).
+  red.
+  intros f F afa w.
+  refine open_constr:((fun x => _) <$> afa (_ w)); try typeclasses_eauto.
+  - apply mkMetadata;
+      Control.dispatch
+        [ (fun _ => apply name)
+          ; (fun _ => apply type_alias)
+          ; (fun _ => apply variable_type)
+          ; (fun _ => apply normalized_type)
+          ; (fun _ => apply x)
+          ; (fun _ => apply is_global)
+          ; (fun _ => apply is_deterministic)
+          ; (fun _ => apply is_non_deterministic)
+          ; (fun _ => apply from_pointer)
+          ; (fun _ => apply is_pointer)
+          ; (fun _ => apply is_sized_pointer)
+          ; (fun _ => apply is_sized)
+          ; (fun _ => apply is_aggregate)
+          ; (fun _ => apply is_indexable)
+          ; (fun _ => apply is_vector)
+          ; (fun _ => apply is_array)
+          ; (fun _ => apply is_struct)
+          ; (fun _ => apply is_non_void)
+          ; (fun _ => apply is_ptr_vector)
+          ; (fun _ => apply is_sized_ptr_vector)
+          ; (fun _ => apply is_sized_type_alias)
+          ; (fun _ => apply is_first_class_type)
+          ; (fun _ => apply is_function_pointer)
+        ];
+      apply w.
+  - apply is_local.
+Defined.
+
+Definition type_alias' {s : StorageType} : Lens' (Metadata s) (Component s Field typ).
+  red.
+  intros f F afa w.
+  refine open_constr:((fun x => _) <$> afa (_ w)); try typeclasses_eauto.
+  - apply mkMetadata;
+      Control.dispatch
+        [ (fun _ => apply name)
+          ; (fun _ => apply x)
+          ; (fun _ => apply variable_type)
+          ; (fun _ => apply normalized_type)
+          ; (fun _ => apply is_local)
+          ; (fun _ => apply is_global)
+          ; (fun _ => apply is_deterministic)
+          ; (fun _ => apply is_non_deterministic)
+          ; (fun _ => apply from_pointer)
+          ; (fun _ => apply is_pointer)
+          ; (fun _ => apply is_sized_pointer)
+          ; (fun _ => apply is_sized)
+          ; (fun _ => apply is_aggregate)
+          ; (fun _ => apply is_indexable)
+          ; (fun _ => apply is_vector)
+          ; (fun _ => apply is_array)
+          ; (fun _ => apply is_struct)
+          ; (fun _ => apply is_non_void)
+          ; (fun _ => apply is_ptr_vector)
+          ; (fun _ => apply is_sized_ptr_vector)
+          ; (fun _ => apply is_sized_type_alias)
+          ; (fun _ => apply is_first_class_type)
+          ; (fun _ => apply is_function_pointer)
+        ];
+      apply w.
+  - apply type_alias.
+Defined.
+
+Definition variable_type' {s : StorageType} : Lens' (Metadata s) (Component s Field typ).
+  red.
+  intros f F afa w.
+  refine open_constr:((fun x => _) <$> afa (_ w)); try typeclasses_eauto.
+  - apply mkMetadata;
+      Control.dispatch
+        [ (fun _ => apply name)
+          ; (fun _ => apply type_alias)
+          ; (fun _ => apply x)
+          ; (fun _ => apply normalized_type)
+          ; (fun _ => apply is_local)
+          ; (fun _ => apply is_global)
+          ; (fun _ => apply is_deterministic)
+          ; (fun _ => apply is_non_deterministic)
+          ; (fun _ => apply from_pointer)
+          ; (fun _ => apply is_pointer)
+          ; (fun _ => apply is_sized_pointer)
+          ; (fun _ => apply is_sized)
+          ; (fun _ => apply is_aggregate)
+          ; (fun _ => apply is_indexable)
+          ; (fun _ => apply is_vector)
+          ; (fun _ => apply is_array)
+          ; (fun _ => apply is_struct)
+          ; (fun _ => apply is_non_void)
+          ; (fun _ => apply is_ptr_vector)
+          ; (fun _ => apply is_sized_ptr_vector)
+          ; (fun _ => apply is_sized_type_alias)
+          ; (fun _ => apply is_first_class_type)
+          ; (fun _ => apply is_function_pointer)
+        ];
+      apply w.
+  - apply variable_type.
+Defined.
+
+Definition normalized_type' {s : StorageType} : Lens' (Metadata s) (Component s Field typ).
+  red.
+  intros f F afa w.
+  refine open_constr:((fun x => _) <$> afa (_ w)); try typeclasses_eauto.
+  - apply mkMetadata;
+      Control.dispatch
+        [ (fun _ => apply name)
+          ; (fun _ => apply type_alias)
+          ; (fun _ => apply variable_type)
+          ; (fun _ => apply x)
+          ; (fun _ => apply is_local)
+          ; (fun _ => apply is_global)
+          ; (fun _ => apply is_deterministic)
+          ; (fun _ => apply is_non_deterministic)
+          ; (fun _ => apply from_pointer)
+          ; (fun _ => apply is_pointer)
+          ; (fun _ => apply is_sized_pointer)
+          ; (fun _ => apply is_sized)
+          ; (fun _ => apply is_aggregate)
+          ; (fun _ => apply is_indexable)
+          ; (fun _ => apply is_vector)
+          ; (fun _ => apply is_array)
+          ; (fun _ => apply is_struct)
+          ; (fun _ => apply is_non_void)
+          ; (fun _ => apply is_ptr_vector)
+          ; (fun _ => apply is_sized_ptr_vector)
+          ; (fun _ => apply is_sized_type_alias)
+          ; (fun _ => apply is_first_class_type)
+          ; (fun _ => apply is_function_pointer)
+        ];
+      apply w.
+  - apply normalized_type.
+Defined.
+
+Definition is_deterministic' {s : StorageType} : Lens' (Metadata s) (Component s Field unit).
+  red.
+  intros f F afa w.
+  refine open_constr:((fun x => _) <$> afa (_ w)); try typeclasses_eauto.
+  - apply mkMetadata;
+      Control.dispatch
+        [ (fun _ => apply name)
+          ; (fun _ => apply type_alias)
+          ; (fun _ => apply variable_type)
+          ; (fun _ => apply normalized_type)
+          ; (fun _ => apply is_local)
+          ; (fun _ => apply is_global)
+          ; (fun _ => apply x)
+          ; (fun _ => apply is_non_deterministic)
+          ; (fun _ => apply from_pointer)
+          ; (fun _ => apply is_pointer)
+          ; (fun _ => apply is_sized_pointer)
+          ; (fun _ => apply is_sized)
+          ; (fun _ => apply is_aggregate)
+          ; (fun _ => apply is_indexable)
+          ; (fun _ => apply is_vector)
+          ; (fun _ => apply is_array)
+          ; (fun _ => apply is_struct)
+          ; (fun _ => apply is_non_void)
+          ; (fun _ => apply is_ptr_vector)
+          ; (fun _ => apply is_sized_ptr_vector)
+          ; (fun _ => apply is_sized_type_alias)
+          ; (fun _ => apply is_first_class_type)
+          ; (fun _ => apply is_function_pointer)
+        ];
+      apply w.
+  - apply is_deterministic.
+Defined.
+
+Definition is_non_deterministic' {s : StorageType} : Lens' (Metadata s) (Component s Field unit).
+  red.
+  intros f F afa w.
+  refine open_constr:((fun x => _) <$> afa (_ w)); try typeclasses_eauto.
+  - apply mkMetadata;
+      Control.dispatch
+        [ (fun _ => apply name)
+          ; (fun _ => apply type_alias)
+          ; (fun _ => apply variable_type)
+          ; (fun _ => apply normalized_type)
+          ; (fun _ => apply is_local)
+          ; (fun _ => apply is_global)
+          ; (fun _ => apply is_deterministic)
+          ; (fun _ => apply x)
+          ; (fun _ => apply from_pointer)
+          ; (fun _ => apply is_pointer)
+          ; (fun _ => apply is_sized_pointer)
+          ; (fun _ => apply is_sized)
+          ; (fun _ => apply is_aggregate)
+          ; (fun _ => apply is_indexable)
+          ; (fun _ => apply is_vector)
+          ; (fun _ => apply is_array)
+          ; (fun _ => apply is_struct)
+          ; (fun _ => apply is_non_void)
+          ; (fun _ => apply is_ptr_vector)
+          ; (fun _ => apply is_sized_ptr_vector)
+          ; (fun _ => apply is_sized_type_alias)
+          ; (fun _ => apply is_first_class_type)
+          ; (fun _ => apply is_function_pointer)
+        ];
+      apply w.
+  - apply is_non_deterministic.
+Defined.
+
+Definition invert_option_unit (x : option unit) : option unit
+  := match x with
+     | Some _ => None
+     | None => Some tt
+     end.
+
+Definition deterministic' : Lens' (Metadata FieldOf) bool.
+  red.
+  intros F HF f fields.
+  ltac1:(pose proof (is_some (fields .^ is_deterministic')) as deterministicb).
+  apply f in deterministicb.
+  apply (fmap
+           (fun (b : bool) =>
+              if b
+              then (fields
+                    & @is_deterministic' FieldOf .~ ret tt
+                    & @is_non_deterministic' FieldOf .~ None)
+              else (fields
+                    & @is_deterministic' FieldOf .~ None
+                    & @is_non_deterministic' FieldOf .~ ret tt))).
+  apply deterministicb.
+Defined.
+
+Definition from_pointer' {s : StorageType} : Lens' (Metadata s) (Component s Field Ent).
+  red.
+  intros f F afa w.
+  refine open_constr:((fun x => _) <$> afa (_ w)); try typeclasses_eauto.
+  - apply mkMetadata;
+      Control.dispatch
+        [ (fun _ => apply name)
+          ; (fun _ => apply type_alias)
+          ; (fun _ => apply variable_type)
+          ; (fun _ => apply normalized_type)
+          ; (fun _ => apply is_local)
+          ; (fun _ => apply is_global)
+          ; (fun _ => apply is_deterministic)
+          ; (fun _ => apply is_non_deterministic)
+          ; (fun _ => apply x)
+          ; (fun _ => apply is_pointer)
+          ; (fun _ => apply is_sized_pointer)
+          ; (fun _ => apply is_sized)
+          ; (fun _ => apply is_aggregate)
+          ; (fun _ => apply is_indexable)
+          ; (fun _ => apply is_vector)
+          ; (fun _ => apply is_array)
+          ; (fun _ => apply is_struct)
+          ; (fun _ => apply is_non_void)
+          ; (fun _ => apply is_ptr_vector)
+          ; (fun _ => apply is_sized_ptr_vector)
+          ; (fun _ => apply is_sized_type_alias)
+          ; (fun _ => apply is_first_class_type)
+          ; (fun _ => apply is_function_pointer)
+        ];
+      apply w.
+  - apply from_pointer.
+Defined.
+
+Definition is_pointer' {s : StorageType} : Lens' (Metadata s) (Component s Field unit).
+  red.
+  intros f F afa w.
+  refine open_constr:((fun x => _) <$> afa (_ w)); try typeclasses_eauto.
+  - apply mkMetadata;
+      Control.dispatch
+        [ (fun _ => apply name)
+          ; (fun _ => apply type_alias)
+          ; (fun _ => apply variable_type)
+          ; (fun _ => apply normalized_type)
+          ; (fun _ => apply is_local)
+          ; (fun _ => apply is_global)
+          ; (fun _ => apply is_deterministic)
+          ; (fun _ => apply is_non_deterministic)
+          ; (fun _ => apply from_pointer)
+          ; (fun _ => apply x)
+          ; (fun _ => apply is_sized_pointer)
+          ; (fun _ => apply is_sized)
+          ; (fun _ => apply is_aggregate)
+          ; (fun _ => apply is_indexable)
+          ; (fun _ => apply is_vector)
+          ; (fun _ => apply is_array)
+          ; (fun _ => apply is_struct)
+          ; (fun _ => apply is_non_void)
+          ; (fun _ => apply is_ptr_vector)
+          ; (fun _ => apply is_sized_ptr_vector)
+          ; (fun _ => apply is_sized_type_alias)
+          ; (fun _ => apply is_first_class_type)
+          ; (fun _ => apply is_function_pointer)
+        ];
+      apply w.
+  - apply is_pointer.
+Defined.
+
+Definition is_sized_pointer' {s : StorageType} : Lens' (Metadata s) (Component s Field unit).
+  red.
+  intros f F afa w.
+  refine open_constr:((fun x => _) <$> afa (_ w)); try typeclasses_eauto.
+  - apply mkMetadata;
+      Control.dispatch
+        [ (fun _ => apply name)
+          ; (fun _ => apply type_alias)
+          ; (fun _ => apply variable_type)
+          ; (fun _ => apply normalized_type)
+          ; (fun _ => apply is_local)
+          ; (fun _ => apply is_global)
+          ; (fun _ => apply is_deterministic)
+          ; (fun _ => apply is_non_deterministic)
+          ; (fun _ => apply from_pointer)
+          ; (fun _ => apply is_pointer)
+          ; (fun _ => apply x)
+          ; (fun _ => apply is_sized)
+          ; (fun _ => apply is_aggregate)
+          ; (fun _ => apply is_indexable)
+          ; (fun _ => apply is_vector)
+          ; (fun _ => apply is_array)
+          ; (fun _ => apply is_struct)
+          ; (fun _ => apply is_non_void)
+          ; (fun _ => apply is_ptr_vector)
+          ; (fun _ => apply is_sized_ptr_vector)
+          ; (fun _ => apply is_sized_type_alias)
+          ; (fun _ => apply is_first_class_type)
+          ; (fun _ => apply is_function_pointer)
+        ];
+      apply w.
+  - apply is_sized_pointer.
+Defined.
+
+Definition is_sized' {s : StorageType} : Lens' (Metadata s) (Component s Field unit).
+  red.
+  intros f F afa w.
+  refine open_constr:((fun x => _) <$> afa (_ w)); try typeclasses_eauto.
+  - apply mkMetadata;
+      Control.dispatch
+        [ (fun _ => apply name)
+          ; (fun _ => apply type_alias)
+          ; (fun _ => apply variable_type)
+          ; (fun _ => apply normalized_type)
+          ; (fun _ => apply is_local)
+          ; (fun _ => apply is_global)
+          ; (fun _ => apply is_deterministic)
+          ; (fun _ => apply is_non_deterministic)
+          ; (fun _ => apply from_pointer)
+          ; (fun _ => apply is_pointer)
+          ; (fun _ => apply is_sized_pointer)
+          ; (fun _ => apply x)
+          ; (fun _ => apply is_aggregate)
+          ; (fun _ => apply is_indexable)
+          ; (fun _ => apply is_vector)
+          ; (fun _ => apply is_array)
+          ; (fun _ => apply is_struct)
+          ; (fun _ => apply is_non_void)
+          ; (fun _ => apply is_ptr_vector)
+          ; (fun _ => apply is_sized_ptr_vector)
+          ; (fun _ => apply is_sized_type_alias)
+          ; (fun _ => apply is_first_class_type)
+          ; (fun _ => apply is_function_pointer)
+        ];
+      apply w.
+  - apply is_sized.
+Defined.
+
+Definition is_aggregate' {s : StorageType} : Lens' (Metadata s) (Component s Field unit).
+  red.
+  intros f F afa w.
+  refine open_constr:((fun x => _) <$> afa (_ w)); try typeclasses_eauto.
+  - apply mkMetadata;
+      Control.dispatch
+        [ (fun _ => apply name)
+          ; (fun _ => apply type_alias)
+          ; (fun _ => apply variable_type)
+          ; (fun _ => apply normalized_type)
+          ; (fun _ => apply is_local)
+          ; (fun _ => apply is_global)
+          ; (fun _ => apply is_deterministic)
+          ; (fun _ => apply is_non_deterministic)
+          ; (fun _ => apply from_pointer)
+          ; (fun _ => apply is_pointer)
+          ; (fun _ => apply is_sized_pointer)
+          ; (fun _ => apply is_sized)
+          ; (fun _ => apply x)
+          ; (fun _ => apply is_indexable)
+          ; (fun _ => apply is_vector)
+          ; (fun _ => apply is_array)
+          ; (fun _ => apply is_struct)
+          ; (fun _ => apply is_non_void)
+          ; (fun _ => apply is_ptr_vector)
+          ; (fun _ => apply is_sized_ptr_vector)
+          ; (fun _ => apply is_sized_type_alias)
+          ; (fun _ => apply is_first_class_type)
+          ; (fun _ => apply is_function_pointer)
+        ];
+      apply w.
+  - apply is_aggregate.
+Defined.
+
+Definition is_indexable' {s : StorageType} : Lens' (Metadata s) (Component s Field unit).
+  red.
+  intros f F afa w.
+  refine open_constr:((fun x => _) <$> afa (_ w)); try typeclasses_eauto.
+  - apply mkMetadata;
+      Control.dispatch
+        [ (fun _ => apply name)
+          ; (fun _ => apply type_alias)
+          ; (fun _ => apply variable_type)
+          ; (fun _ => apply normalized_type)
+          ; (fun _ => apply is_local)
+          ; (fun _ => apply is_global)
+          ; (fun _ => apply is_deterministic)
+          ; (fun _ => apply is_non_deterministic)
+          ; (fun _ => apply from_pointer)
+          ; (fun _ => apply is_pointer)
+          ; (fun _ => apply is_sized_pointer)
+          ; (fun _ => apply is_sized)
+          ; (fun _ => apply is_aggregate)
+          ; (fun _ => apply x)
+          ; (fun _ => apply is_vector)
+          ; (fun _ => apply is_array)
+          ; (fun _ => apply is_struct)
+          ; (fun _ => apply is_non_void)
+          ; (fun _ => apply is_ptr_vector)
+          ; (fun _ => apply is_sized_ptr_vector)
+          ; (fun _ => apply is_sized_type_alias)
+          ; (fun _ => apply is_first_class_type)
+          ; (fun _ => apply is_function_pointer)
+        ];
+      apply w.
+  - apply is_indexable.
+Defined.
+
+Definition is_vector' {s : StorageType} : Lens' (Metadata s) (Component s Field unit).
+  red.
+  intros f F afa w.
+  refine open_constr:((fun x => _) <$> afa (_ w)); try typeclasses_eauto.
+  - apply mkMetadata;
+      Control.dispatch
+        [ (fun _ => apply name)
+          ; (fun _ => apply type_alias)
+          ; (fun _ => apply variable_type)
+          ; (fun _ => apply normalized_type)
+          ; (fun _ => apply is_local)
+          ; (fun _ => apply is_global)
+          ; (fun _ => apply is_deterministic)
+          ; (fun _ => apply is_non_deterministic)
+          ; (fun _ => apply from_pointer)
+          ; (fun _ => apply is_pointer)
+          ; (fun _ => apply is_sized_pointer)
+          ; (fun _ => apply is_sized)
+          ; (fun _ => apply is_aggregate)
+          ; (fun _ => apply is_indexable)
+          ; (fun _ => apply x)
+          ; (fun _ => apply is_array)
+          ; (fun _ => apply is_struct)
+          ; (fun _ => apply is_non_void)
+          ; (fun _ => apply is_ptr_vector)
+          ; (fun _ => apply is_sized_ptr_vector)
+          ; (fun _ => apply is_sized_type_alias)
+          ; (fun _ => apply is_first_class_type)
+          ; (fun _ => apply is_function_pointer)
+        ];
+      apply w.
+  - apply is_vector.
+Defined.
+
+Definition is_array' {s : StorageType} : Lens' (Metadata s) (Component s Field unit).
+  red.
+  intros f F afa w.
+  refine open_constr:((fun x => _) <$> afa (_ w)); try typeclasses_eauto.
+  - apply mkMetadata;
+      Control.dispatch
+        [ (fun _ => apply name)
+          ; (fun _ => apply type_alias)
+          ; (fun _ => apply variable_type)
+          ; (fun _ => apply normalized_type)
+          ; (fun _ => apply is_local)
+          ; (fun _ => apply is_global)
+          ; (fun _ => apply is_deterministic)
+          ; (fun _ => apply is_non_deterministic)
+          ; (fun _ => apply from_pointer)
+          ; (fun _ => apply is_pointer)
+          ; (fun _ => apply is_sized_pointer)
+          ; (fun _ => apply is_sized)
+          ; (fun _ => apply is_aggregate)
+          ; (fun _ => apply is_indexable)
+          ; (fun _ => apply is_vector)
+          ; (fun _ => apply x)
+          ; (fun _ => apply is_struct)
+          ; (fun _ => apply is_non_void)
+          ; (fun _ => apply is_ptr_vector)
+          ; (fun _ => apply is_sized_ptr_vector)
+          ; (fun _ => apply is_sized_type_alias)
+          ; (fun _ => apply is_first_class_type)
+          ; (fun _ => apply is_function_pointer)
+        ];
+      apply w.
+  - apply is_array.
+Defined.
+
+Definition is_struct' {s : StorageType} : Lens' (Metadata s) (Component s Field unit).
+  red.
+  intros f F afa w.
+  refine open_constr:((fun x => _) <$> afa (_ w)); try typeclasses_eauto.
+  - apply mkMetadata;
+      Control.dispatch
+        [ (fun _ => apply name)
+          ; (fun _ => apply type_alias)
+          ; (fun _ => apply variable_type)
+          ; (fun _ => apply normalized_type)
+          ; (fun _ => apply is_local)
+          ; (fun _ => apply is_global)
+          ; (fun _ => apply is_deterministic)
+          ; (fun _ => apply is_non_deterministic)
+          ; (fun _ => apply from_pointer)
+          ; (fun _ => apply is_pointer)
+          ; (fun _ => apply is_sized_pointer)
+          ; (fun _ => apply is_sized)
+          ; (fun _ => apply is_aggregate)
+          ; (fun _ => apply is_indexable)
+          ; (fun _ => apply is_vector)
+          ; (fun _ => apply is_array)
+          ; (fun _ => apply x)
+          ; (fun _ => apply is_non_void)
+          ; (fun _ => apply is_ptr_vector)
+          ; (fun _ => apply is_sized_ptr_vector)
+          ; (fun _ => apply is_sized_type_alias)
+          ; (fun _ => apply is_first_class_type)
+          ; (fun _ => apply is_function_pointer)
+        ];
+      apply w.
+  - apply is_struct.
+Defined.
+
+Definition is_non_void' {s : StorageType} : Lens' (Metadata s) (Component s Field unit).
+  red.
+  intros f F afa w.
+  refine open_constr:((fun x => _) <$> afa (_ w)); try typeclasses_eauto.
+  - apply mkMetadata;
+      Control.dispatch
+        [ (fun _ => apply name)
+          ; (fun _ => apply type_alias)
+          ; (fun _ => apply variable_type)
+          ; (fun _ => apply normalized_type)
+          ; (fun _ => apply is_local)
+          ; (fun _ => apply is_global)
+          ; (fun _ => apply is_deterministic)
+          ; (fun _ => apply is_non_deterministic)
+          ; (fun _ => apply from_pointer)
+          ; (fun _ => apply is_pointer)
+          ; (fun _ => apply is_sized_pointer)
+          ; (fun _ => apply is_sized)
+          ; (fun _ => apply is_aggregate)
+          ; (fun _ => apply is_indexable)
+          ; (fun _ => apply is_vector)
+          ; (fun _ => apply is_array)
+          ; (fun _ => apply is_struct)
+          ; (fun _ => apply x)
+          ; (fun _ => apply is_ptr_vector)
+          ; (fun _ => apply is_sized_ptr_vector)
+          ; (fun _ => apply is_sized_type_alias)
+          ; (fun _ => apply is_first_class_type)
+          ; (fun _ => apply is_function_pointer)
+        ];
+      apply w.
+  - apply is_non_void.
+Defined.
+
+Definition is_ptr_vector' {s : StorageType} : Lens' (Metadata s) (Component s Field unit).
+  red.
+  intros f F afa w.
+  refine open_constr:((fun x => _) <$> afa (_ w)); try typeclasses_eauto.
+  - apply mkMetadata;
+      Control.dispatch
+        [ (fun _ => apply name)
+          ; (fun _ => apply type_alias)
+          ; (fun _ => apply variable_type)
+          ; (fun _ => apply normalized_type)
+          ; (fun _ => apply is_local)
+          ; (fun _ => apply is_global)
+          ; (fun _ => apply is_deterministic)
+          ; (fun _ => apply is_non_deterministic)
+          ; (fun _ => apply from_pointer)
+          ; (fun _ => apply is_pointer)
+          ; (fun _ => apply is_sized_pointer)
+          ; (fun _ => apply is_sized)
+          ; (fun _ => apply is_aggregate)
+          ; (fun _ => apply is_indexable)
+          ; (fun _ => apply is_vector)
+          ; (fun _ => apply is_array)
+          ; (fun _ => apply is_struct)
+          ; (fun _ => apply is_non_void)
+          ; (fun _ => apply x)
+          ; (fun _ => apply is_sized_ptr_vector)
+          ; (fun _ => apply is_sized_type_alias)
+          ; (fun _ => apply is_first_class_type)
+          ; (fun _ => apply is_function_pointer)
+        ];
+      apply w.
+  - apply is_ptr_vector.
+Defined.
+
+Definition is_sized_ptr_vector' {s : StorageType} : Lens' (Metadata s) (Component s Field unit).
+  red.
+  intros f F afa w.
+  refine open_constr:((fun x => _) <$> afa (_ w)); try typeclasses_eauto.
+  - apply mkMetadata;
+      Control.dispatch
+        [ (fun _ => apply name)
+          ; (fun _ => apply type_alias)
+          ; (fun _ => apply variable_type)
+          ; (fun _ => apply normalized_type)
+          ; (fun _ => apply is_local)
+          ; (fun _ => apply is_global)
+          ; (fun _ => apply is_deterministic)
+          ; (fun _ => apply is_non_deterministic)
+          ; (fun _ => apply from_pointer)
+          ; (fun _ => apply is_pointer)
+          ; (fun _ => apply is_sized_pointer)
+          ; (fun _ => apply is_sized)
+          ; (fun _ => apply is_aggregate)
+          ; (fun _ => apply is_indexable)
+          ; (fun _ => apply is_vector)
+          ; (fun _ => apply is_array)
+          ; (fun _ => apply is_struct)
+          ; (fun _ => apply is_non_void)
+          ; (fun _ => apply is_ptr_vector)
+          ; (fun _ => apply x)
+          ; (fun _ => apply is_sized_type_alias)
+          ; (fun _ => apply is_first_class_type)
+          ; (fun _ => apply is_function_pointer)
+        ];
+      apply w.
+  - apply is_sized_ptr_vector.
+Defined.
+
+Definition is_sized_type_alias' {s : StorageType} : Lens' (Metadata s) (Component s Field unit).
+  red.
+  intros f F afa w.
+  refine open_constr:((fun x => _) <$> afa (_ w)); try typeclasses_eauto.
+  - apply mkMetadata;
+      Control.dispatch
+        [ (fun _ => apply name)
+          ; (fun _ => apply type_alias)
+          ; (fun _ => apply variable_type)
+          ; (fun _ => apply normalized_type)
+          ; (fun _ => apply is_local)
+          ; (fun _ => apply is_global)
+          ; (fun _ => apply is_deterministic)
+          ; (fun _ => apply is_non_deterministic)
+          ; (fun _ => apply from_pointer)
+          ; (fun _ => apply is_pointer)
+          ; (fun _ => apply is_sized_pointer)
+          ; (fun _ => apply is_sized)
+          ; (fun _ => apply is_aggregate)
+          ; (fun _ => apply is_indexable)
+          ; (fun _ => apply is_vector)
+          ; (fun _ => apply is_array)
+          ; (fun _ => apply is_struct)
+          ; (fun _ => apply is_non_void)
+          ; (fun _ => apply is_ptr_vector)
+          ; (fun _ => apply is_sized_ptr_vector)
+          ; (fun _ => apply x)
+          ; (fun _ => apply is_first_class_type)
+          ; (fun _ => apply is_function_pointer)
+        ];
+      apply w.
+  - apply is_sized_type_alias.
+Defined.
+
+Definition is_first_class_type' {s : StorageType} : Lens' (Metadata s) (Component s Field unit).
+  red.
+  intros f F afa w.
+  refine open_constr:((fun x => _) <$> afa (_ w)); try typeclasses_eauto.
+  - apply mkMetadata;
+      Control.dispatch
+        [ (fun _ => apply name)
+          ; (fun _ => apply type_alias)
+          ; (fun _ => apply variable_type)
+          ; (fun _ => apply normalized_type)
+          ; (fun _ => apply is_local)
+          ; (fun _ => apply is_global)
+          ; (fun _ => apply is_deterministic)
+          ; (fun _ => apply is_non_deterministic)
+          ; (fun _ => apply from_pointer)
+          ; (fun _ => apply is_pointer)
+          ; (fun _ => apply is_sized_pointer)
+          ; (fun _ => apply is_sized)
+          ; (fun _ => apply is_aggregate)
+          ; (fun _ => apply is_indexable)
+          ; (fun _ => apply is_vector)
+          ; (fun _ => apply is_array)
+          ; (fun _ => apply is_struct)
+          ; (fun _ => apply is_non_void)
+          ; (fun _ => apply is_ptr_vector)
+          ; (fun _ => apply is_sized_ptr_vector)
+          ; (fun _ => apply is_sized_type_alias)
+          ; (fun _ => apply x)
+          ; (fun _ => apply is_function_pointer)
+        ];
+      apply w.
+  - apply is_first_class_type.
+Defined.
+
+Definition is_function_pointer' {s : StorageType} : Lens' (Metadata s) (Component s Field unit).
+  red.
+  intros f F afa w.
+  refine open_constr:((fun x => _) <$> afa (_ w)); try typeclasses_eauto.
+  - apply mkMetadata;
+      Control.dispatch
+        [ (fun _ => apply name)
+          ; (fun _ => apply type_alias)
+          ; (fun _ => apply variable_type)
+          ; (fun _ => apply normalized_type)
+          ; (fun _ => apply is_local)
+          ; (fun _ => apply is_global)
+          ; (fun _ => apply is_deterministic)
+          ; (fun _ => apply is_non_deterministic)
+          ; (fun _ => apply from_pointer)
+          ; (fun _ => apply is_pointer)
+          ; (fun _ => apply is_sized_pointer)
+          ; (fun _ => apply is_sized)
+          ; (fun _ => apply is_aggregate)
+          ; (fun _ => apply is_indexable)
+          ; (fun _ => apply is_vector)
+          ; (fun _ => apply is_array)
+          ; (fun _ => apply is_struct)
+          ; (fun _ => apply is_non_void)
+          ; (fun _ => apply is_ptr_vector)
+          ; (fun _ => apply is_sized_ptr_vector)
+          ; (fun _ => apply is_sized_type_alias)
+          ; (fun _ => apply is_first_class_type)
+          ; (fun _ => apply x)
+        ];
+      apply w.
+  - apply is_function_pointer.
+Defined.
+
+Definition ident_to_raw_id (i : ident) :=
+  match i with
+  | ID_Global id => id
+  | ID_Local id => id
+  end.
+
+Definition entl {m} `{HM: Monad m} (e : Ent) : Lens' (Metadata (WorldOf m)) (Metadata FieldOf).
+  red.
+  intros f F afa w.
+
+  refine
+    open_constr:
+      (let eid := unEnt e in
+       ((fun x => _) <$> afa (_ w))); try typeclasses_eauto.
+  - apply mkMetadata; red;
+      applyMetadataConstructors (fun _ => refine open_constr:(optSetMapRaw (_ x) eid (_ w))).
+  - intros w'.
+    apply (mkMetadata FieldOf);
+      refine open_constr:(IM.Raw.find eid (_ w'));
+      Control.dispatch metadataConstructors.
+Defined.
+
+Definition deleteEntity {w} {m} `{Monad m} `{@MetadataStore m Metadata (SystemState w m)} (e : Ent) : SystemT w m unit
+  := let eid := unEnt e in
+     metadata .@ entl e .= def;;
+     entities %= (fun ents => IS.remove eid ents);;
+     ret tt.
+
+Definition deleteEntities
+  {w : StorageType -> Type} {m : Type -> Type}
+  `{Monad m} `{@MetadataStore m Metadata (SystemState w m)} {A}
+  (es : IM.Raw.t A) : SystemT w m unit
+  := IM.Raw.fold (fun k _ acc => deleteEntity (mkEnt k);; acc) es (ret tt).
+
+Definition names'' {m} : Traversal (Metadata (WorldOf m)) (Metadata (WorldOf m)) (Component (WorldOf m) Field ident) (Component (WorldOf m) Field ident).
+  red.
+  intros f F focus meta.
+  refine open_constr:(pure (mkMetadata (WorldOf m)) <*> _ <*> _ <*> _ <*> _ <*> _ <*> _ <*> _
+                        <*> _ <*> _ <*> _ <*> _ <*> _ <*> _ <*> _ <*> _ <*> _ <*> _ <*> _
+                        <*> _ <*> _ <*> _ <*> _ <*> _);
+    try typeclasses_eauto; try eauto.
+  - apply (focus (name _ meta)).
+  - apply (pure (type_alias _ meta)).
+  - apply (pure (variable_type _ meta)).
+  - apply (pure (normalized_type _ meta)).
+  - apply (pure (is_local _ meta)).
+  - apply (pure (is_global _ meta)).
+  - apply (pure (is_deterministic _ meta)).
+  - apply (pure (is_non_deterministic _ meta)).
+  - apply (pure (from_pointer _ meta)).
+  - apply (pure (is_pointer _ meta)).
+  - apply (pure (is_sized_pointer _ meta)).
+  - apply (pure (is_sized _ meta)).
+  - apply (pure (is_aggregate _ meta)).
+  - apply (pure (is_indexable _ meta)).
+  - apply (pure (is_vector _ meta)).
+  - apply (pure (is_array _ meta)).
+  - apply (pure (is_struct _ meta)).
+  - apply (pure (is_non_void _ meta)).
+  - apply (pure (is_ptr_vector _ meta)).
+  - apply (pure (is_sized_ptr_vector _ meta)).
+  - apply (pure (is_sized_type_alias _ meta)).
+  - apply (pure (is_first_class_type _ meta)).
+  - apply (pure (is_function_pointer _ meta)).
+Defined.
+
+Definition emap
+  {w m} `{Monad m} `{@MetadataStore m Metadata (SystemState w m)}
+  {es E} `{ToEnt E} `{Foldable es E}
+  (t : EntTarget w m (E:=E)) (q : QueryT Metadata m (Metadata SetterOf)) : SystemT w m unit
+  := es <- t;;
+     fold _
+       (fun (k : E) (acc : SystemT w m unit) =>
+          let e := toEnt k in
+          meta <- getEntity e;;
+          sets <- lift (unQueryT q e meta);;
+          match sets with
+          | None =>
+              acc
+          | Some s =>
+              setEntity e s;;
+              acc
+          end
+       ) (ret tt) es.
+
+(* Filter out Nones from a set of options *)
+Class FilterNone T :=
+  { filterNone : forall {a}, T (option a) -> T a }.
+
+#[global] Instance FilterNone_list : FilterNone list :=
+  { filterNone _ l := fold_right (fun x acc => match x with | None => acc | Some x => x :: acc end) [] l }.
+
+Program Definition efor
+  {w m} `{Monad m} `{@MetadataStore m Metadata (SystemState w m)}
+  {a}
+  (t : @EntTarget (list Ent) Ent _ _ w m) (q : QueryT Metadata m a) : SystemT w m (list a)
+  := es <- t;;
+     _.
+Next Obligation.
+  refine open_constr:(fmap filterNone _);
+    try typeclasses_eauto.
+  refine open_constr:((fun a b => mapT b a) es (fun e => cs <- getEntity (toEnt e);; lift (unQueryT q e cs)));
+    try typeclasses_eauto.
+Defined.
+
+Program Definition efind
+  {w m a} `{Monad m} `{@MetadataStore m Metadata (SystemState w m)}
+  {es E} `{ToEnt E} `{Foldable es E}
+  (t : EntTarget w m (E:=E))
+  (q : QueryT Metadata m a) : SystemT w m (option a)
+  := es <- t;;
+     _.
+Next Obligation.
+  refine
+    open_constr:
+      (fold _
+         (fun (k : E) (acc : SystemT w m (option a)) =>
+            let e := toEnt k in
+            meta <- getEntity e;;
+            qres <- lift (unQueryT q e meta);;
+            match qres with
+            | Some _ => ret qres
+            | None => acc
+            end
+         ) (ret None) es);
+    try typeclasses_eauto.
+Defined.

--- a/src/rocq/GenMetadata.v
+++ b/src/rocq/GenMetadata.v
@@ -12,6 +12,7 @@ Import LensNotations.
 #[local] Open Scope monad_scope.
 #[local] Open Scope lens.
 
+Require Import ExtLib.Data.List.
 Require Import ExtLib.Data.Monads.StateMonad.
 Require Import ExtLib.Data.Monads.OptionMonad.
 Require Import ExtLib.Data.Monads.ReaderMonad.
@@ -26,6 +27,14 @@ Import MonadPlusNotation.
 Import ApplicativeNotation.
 Import FunctorNotation.
 Import ListNotations.
+
+(* From src/rocq/Utils/ListUtil.v of commit f1ec3588 *)
+Import Monoid.
+#[global] Instance Foldable_list {a} : Foldable (list a) a.
+split.
+intros m M conv l.
+apply (fold_left (fun acc x => monoid_plus M (conv x) acc) l (monoid_unit M)).
+Defined.
 
 Record Metadata s :=
   mkMetadata

--- a/src/rocq/GenMetadata.v
+++ b/src/rocq/GenMetadata.v
@@ -2,15 +2,15 @@ From Ltac2 Require Import Ltac2.
 From Stdlib Require Import List String.
 From Vellvm.Utils Require Import
   IntMaps
-  Monads
-  Default.
+  ListUtil.
 
 From Vellvm.Syntax Require Import
   LLVMAst.
 
-From Vellvm.QC Require Import ECS Lens.
+From GenLLVM Require Import Default ECS Lens.
 Import LensNotations.
-Local Open Scope lens.
+#[local] Open Scope monad_scope.
+#[local] Open Scope lens.
 
 Require Import ExtLib.Data.Monads.StateMonad.
 Require Import ExtLib.Data.Monads.OptionMonad.
@@ -1078,6 +1078,7 @@ Program Definition efor
   := es <- t;;
      _.
 Next Obligation.
+Set Printing All.
   refine open_constr:(fmap filterNone _);
     try typeclasses_eauto.
   refine open_constr:((fun a b => mapT b a) es (fun e => cs <- getEntity (toEnt e);; lift (unQueryT q e cs)));

--- a/src/rocq/Generators.v
+++ b/src/rocq/Generators.v
@@ -1,10 +1,11 @@
-Require Import ZArith PArith Lia List String.
+From Stdlib Require Import ZArith PArith Lia List String.
 Require Import Flocq.IEEE754.Binary Flocq.Core.Zaux Flocq.IEEE754.Bits.
 Require Import Basics RelationClasses.
-Require Import BinIntDef.
+From Stdlib Require Import BinIntDef.
 Import ListNotations.
 
-From QuickChick Require Import QuickChick.
+(* From QuickChick Require Import QuickChick. *)
+From QuickChick Require Import Generators Producer Show Sets.
 Set Warnings "-extraction-opaque-accessed,-extraction".
 
 (** [subst_max] performs as many [subst] as possible, clearing all
@@ -37,16 +38,16 @@ Ltac tuple_inversion :=
   end.
 
 Open Scope string.
-
+(* Locate B754_zero. *)
 Instance show_binary : forall (prec emax : Z), Show (binary_float prec emax) := {
   show c := match c with
-              | B754_zero _ _ false => "+0"
-              | B754_zero _ _ true => "-0"
-              | B754_infinity _ _ false => "+inf"
-              | B754_infinity _ _ true => "-inf"
-              | B754_nan _ _ false _ _ => "+NaN"
-              | B754_nan _ _ true _ _ => "-NaN"
-              | B754_finite _ _ s m e _ => (if s then "" else "-")
+              | @B754_zero _ _ false => "+0"
+              | @B754_zero _ _ true => "-0"
+              | @B754_infinity _ _ false => "+inf"
+              | @B754_infinity _ _ true => "-inf"
+              | @B754_nan _ _ false _ _ => "+NaN"
+              | @B754_nan _ _ true _ _ => "-NaN"
+              | @B754_finite _ _ s m e _ => (if s then "" else "-")
                                         ++ (show_Z (Z.pos m * 2 ^ e))
             end
 }.
@@ -92,7 +93,7 @@ Lemma bounded_unfolded (prec emax : Z)
   (digits (Zpos m) = prec /\ 3 - emax - prec <= e <= emax - prec).
 Proof.
   unfold FLX.Prec_gt_0, SpecFloat.bounded, SpecFloat.canonical_mantissa, SpecFloat.fexp, SpecFloat.emin, FLT.FLT_exp in *.
-  rewrite Bool.andb_true_iff, Z.leb_le, <-Zeq_is_eq_bool, digits2_pos_digits.
+  rewrite Bool.andb_true_iff, Z.leb_le, <-Z.eqb_eq, digits2_pos_digits.
   remember (3 - emax - prec) as emin.
   split; intro.
   all: destruct (Z_lt_le_dec (digits (Zpos m) + e - prec) emin).
@@ -104,25 +105,25 @@ Qed.
 Definition binary32 := binary_float 24 128.
 Definition binary64 := binary_float 53 1024.
 
-(* Generates B754_zero values *)
+Definition bool_gen : G bool :=
+  oneof (ret true) [ret true; ret false].
 
-(* TODO: update typeclasses? *)
-(*
-Definition zerg (prec emax : Z) := 
+(* Generates B754_zero values *)
+Definition zerg (prec emax : Z) : G (binary_float prec emax) := 
   (liftGen (fun (s : bool) => B754_zero prec emax s)) 
-    (choose (true, false)).
+    bool_gen.
 
 (* Generates B754_infinity values *)
 Definition infg (prec emax : Z) := 
   (liftGen (fun (s : bool) => B754_infinity prec emax s))
-    (choose (true, false)).
+    bool_gen.
 
 (* Generates B754_nan values. Needs payload and nan_pl proof *)
 Definition nang (prec emax : Z) 
         (pl : positive) 
         (np : nan_pl prec pl = true) := 
   (liftGen (fun b => B754_nan prec emax b pl np))
-    (choose (true, false)).
+    bool_gen.
 
 Definition boundaries (prec emax : Z) (t : bool) :=
       if t 
@@ -130,27 +131,28 @@ Definition boundaries (prec emax : Z) (t : bool) :=
       else (2^(prec - 1), 2^prec - 1, 3 - emax - prec, emax - prec)%Z.
 
 (* Generates B754_finite values. Needs prec_gt_0 Hmax proof *)
+Definition bindGen' := @bindPf G ProducerGen.
 Program Definition fing (prec emax : Z) 
         (prec_gt_0 : Flocq.Core.FLX.Prec_gt_0 prec)
         (Hmax : (prec < emax)%Z) : G (binary_float prec emax) :=
-  bindGen' (choose (false, true)) (fun t => fun b0 => 
-    bindGen' (returnGen (boundaries prec emax t)) 
+  bindGen' _ _ bool_gen (fun t => fun b0 => 
+    bindGen' _ _ (returnGen (boundaries prec emax t)) 
     (fun '(m_min, m_max, e_min, e_max) => fun b1 =>
-      bindGen' (choose (false, true)) (fun (s : bool) => fun b2 =>
-        bindGen' (choose (m_min, m_max)) (fun (m : Z) => fun b3 =>
-          bindGen' (choose (e_min, e_max)) (fun (e : Z) => fun b4 =>
+      bindGen' _ _ bool_gen (fun (s : bool) => fun b2 =>
+        bindGen' _ _ (choose (m_min, m_max)) (fun (m : Z) => fun b3 =>
+          bindGen' _ _ (choose (e_min, e_max)) (fun (e : Z) => fun b4 =>
             returnGen (B754_finite prec emax s (Z.to_pos m) e _)))))).
 Next Obligation.
   (* get rid of technical junk *)
   clear s b0 b2; rename b3 into b2, b4 into b3.
-  apply semReturn in b1.
-  apply semChoose in b2.
-  apply semChoose in b3.
+  apply @semReturn in b1; try typeclasses eauto.
+  apply @semChoose in b2; try typeclasses eauto.
+  apply @semChoose in b3; try typeclasses eauto.
   all: unfold is_true, set1, boundaries in *.
 
   (* simplify *)
-  apply andb_prop in b2; destruct b2 as [B11 B12].
-  apply andb_prop in b3; destruct b3 as [B21 B22].
+  destruct b2 as [B11 B12].
+  destruct b3 as [B21 B22].
   all: destruct t; try rewrite Z.leb_le in *.
   Opaque Z.sub.
   all: tuple_inversion.
@@ -231,4 +233,3 @@ Definition binary64_gen (pl : positive) (np : nan_pl 53 pl = true)
   : G (binary64) :=
   freq_ zerg64 [(1, zerg64)%nat ; (1, infg64)%nat ;
                 (1, nang64 pl np)%nat ; (7, fing64)%nat].
-*)

--- a/src/rocq/Lens.v
+++ b/src/rocq/Lens.v
@@ -1,0 +1,98 @@
+From Vellvm.Utils Require Import
+  Monads.
+
+Require Import ExtLib.Data.Monads.StateMonad.
+Require Import ExtLib.Structures.Monads.
+Require Import ExtLib.Structures.Functor.
+Require Import ExtLib.Structures.Applicative.
+Require Import ExtLib.Structures.Traversable.
+Import MonadNotation.
+Import ApplicativeNotation.
+Import FunctorNotation.
+
+Record Const (a b : Type) : Type := mkConst { getConst : a }.
+Arguments mkConst {_ _}.
+Arguments getConst {_ _}.
+
+Instance Const_Functor {a} : Functor (Const a).
+split.
+intros A B X X0.
+destruct X0.
+apply (mkConst getConst0).
+Defined.
+
+Definition ASetter s t a b := (a -> IdentityMonad.ident b) -> s -> IdentityMonad.ident t.
+Definition ASetter' s a := (a -> IdentityMonad.ident a) -> s -> IdentityMonad.ident s.
+Definition LensLike (f : Type -> Type) s t a b := (a -> f b) -> s -> f t.
+Definition Lens s t a b := forall {f} `{F: Functor f}, (a -> f b) -> s -> f t.
+Definition Lens' s a := forall {f} `{F: Functor f}, (a -> f a) -> s -> f s.
+Definition Traversal s t a b := forall {f} `{F: Applicative f}, (a -> f b) -> s -> f t.
+
+Definition lift_Lens' {a b} (l : Lens' a b) : Lens a a b b := l.
+
+Definition view {s t a b : Type} (l : Lens s t a b) (w : s) : a
+  := (getConst (l _ _ mkConst w)).
+
+Definition over {s t a b : Type} (l : ASetter s t a b) (f : a -> b) (w : s) : t
+  := IdentityMonad.unIdent (l (fun x => IdentityMonad.mkIdent (f x)) w).
+
+Definition setl {s t a b : Type} (l : ASetter s t a b) (v : b) (w : s) : t
+  := IdentityMonad.unIdent (l (fun _ => IdentityMonad.mkIdent v) w).
+
+Definition assign {m : Type -> Type} {s a b : Type} `{HM : Monad m} `{ST : @MonadState s m}
+  (l : ASetter s s a b) (v : b) : m s
+  := modify (setl l v).
+
+Definition modifying {m : Type -> Type} {s a b : Type} `{HM : Monad m} `{ST : @MonadState s m}
+  (l : ASetter s s a b) (f : a -> b) : m s
+  := modify (over l f).
+
+Definition use {m : Type -> Type} {s a : Type} `{HM : Monad m} `{ST : @MonadState s m}
+  (l : Lens' s a) : m a
+  := gets (view l).
+
+Definition comp' {a b c} (l1 : Lens' a b) (l2 : Lens' b c) : Lens' a c.
+  red in l1, l2.
+  red.
+  intros f F afa x.
+  specialize (l1 f F).
+  specialize (l2 f F).
+  apply l1.
+  - apply l2.
+    apply afa.
+  - apply x.
+Defined.
+
+Definition traversal {f s t a b} (tr : (a -> f b) -> s -> f t) : LensLike f s t a b
+  := tr.
+
+Definition lens_to_asetter {s t a b} : Lens s t a b -> ASetter s t a b.
+  intros l.
+  specialize (l IdentityMonad.ident _).
+  red. apply l.
+Defined.
+
+Definition lens'_to_lens {s a} : Lens' s a -> Lens s s a a.
+  intros l.
+  apply l.
+Defined.
+
+#[global] Coercion lens_to_asetter : Lens >-> ASetter.
+#[global] Coercion lens'_to_lens : Lens' >-> Lens.
+
+Module LensNotations.
+  Declare Scope lens_scope.
+  Delimit Scope lens_scope with lens.
+  Bind Scope lens_scope with Lens.
+
+  Notation "X -l> Y" := (Lens X X Y Y)
+    (at level 99, Y at level 200, right associativity) : type_scope.
+  Notation "a & b" := (b a) (at level 50, only parsing, left associativity) : lens_scope.
+  Notation "a %~ f" := (over a f) (at level 49, left associativity) : lens_scope.
+  Notation "a .~ b" := (setl a b) (at level 49, left associativity) : lens_scope.
+  Notation "a %= f" := (modifying a f) (at level 49, left associativity) : lens_scope.
+  Notation "a .= b" := (assign a b) (at level 49, left associativity) : lens_scope.
+  Notation "a .^ f" := (view f a) (at level 45, left associativity) : lens_scope.
+  (* level 19 to be compatible with Iris .@ *)
+  Notation "a .@ b" := (comp' a b) (at level 19, left associativity) : lens_scope.
+End LensNotations.

--- a/src/rocq/Lens.v
+++ b/src/rocq/Lens.v
@@ -1,7 +1,5 @@
-From Vellvm.Utils Require Import
-  Monads.
-
 Require Import ExtLib.Data.Monads.StateMonad.
+Require Import ExtLib.Data.Monads.IdentityMonad.
 Require Import ExtLib.Structures.Monads.
 Require Import ExtLib.Structures.Functor.
 Require Import ExtLib.Structures.Applicative.

--- a/src/rocq/QCExtractionFix.v
+++ b/src/rocq/QCExtractionFix.v
@@ -1,0 +1,24 @@
+From QuickChick Require Import QuickChick.
+From Stdlib Require Import String Number Decimal.
+
+(* Original codes from QuickChick's ExtractionQC.v.cppo
+
+Extract Inductive Hexadecimal.int => "((Obj.t -> Obj.t) -> (Obj.t -> Obj.t) -> Obj.t) (* Hexadecimal.int *)"
+  [ "(fun x pos _ -> pos (Obj.magic x))"
+    "(fun y _ neg -> neg (Obj.magic y))"
+  ] "(fun i pos neg -> Obj.magic i pos neg)".
+Extract Inductive Number.int => "((Obj.t -> Obj.t) -> (Obj.t -> Obj.t) -> Obj.t) (* Number.int *)"
+  [ "(fun x dec _ -> dec (Obj.magic x))"
+    "(fun y _ hex -> hex (Obj.magic y))"
+  ] "(fun i dec hex -> Obj.magic i dec hex)".
+*)
+
+Extract Inductive Hexadecimal.int => "((Obj.t -> Obj.t) -> (Obj.t -> Obj.t) -> Obj.t) (* Hexadecimal.int *)"
+  [ "(fun x pos _ -> pos (Obj.magic x))"
+    "(fun y _ neg -> neg (Obj.magic y))"
+  ] "(fun pos neg i -> Obj.magic i pos neg)".
+Extract Inductive Number.int => "((Obj.t -> Obj.t) -> (Obj.t -> Obj.t) -> Obj.t) (* Number.int *)"
+  [ "(fun x dec _ -> dec (Obj.magic x))"
+    "(fun y _ hex -> hex (Obj.magic y))"
+  ] "(fun dec hex i -> Obj.magic i dec hex)".
+

--- a/src/rocq/QCVellvm.v
+++ b/src/rocq/QCVellvm.v
@@ -5,27 +5,26 @@
     given an LLVM program that loops forever), and as such we need to
     disable the Coq termination checker to define it.
  *)
-From Vellvm Require Import Semantics.LLVMEvents.
-From Vellvm Require Import Semantics.InterpretationStack.
+Require Import Semantics.LLVMEvents.
+Require Import Semantics.InterpretationStack.
+Require Import Handlers.Handlers.
 
-From Stdlib Require Import
-  String 
-  ZArith.
+From Stdlib Require Import String.
+From Stdlib Require Import ZArith.
 
 From ITree Require Import
      ITree
      Interp.Recursion
      Events.Exception.
 
-From Stdlib Require Import
-  ExtrOcamlBasic
-  ExtrOcamlString.
+(* Require Import ExtrOcamlBasic. *)
+(* Require Import ExtrOcamlString. *)
 
-From QuickChick Require Import QuickChick.
-From Vellvm Require Import ShowAST ReprAST TopLevel LLVMAst DynamicValues.
-From GenLLVM Require Import GenAST.
+(* From QuickChick Require Import QuickChick. *)
+From QuickChick Require Import Show Checker Generators Producer Test.
+From Vellvm Require Import ShowAST ReprAST GenAST TopLevel LLVMAst DynamicValues VellvmIntegers.
 
-Extraction Blacklist String List Char Core Z Format.
+Extraction Blacklist String List Char Core Z Format int.
 
 (* TODO: Use the existing vellvm version of this? Might actually just be ocaml result type. *)
 Inductive MlResult a e :=
@@ -58,26 +57,28 @@ Proof.
 Defined.
 
 Unset Guard Checking.
-Fixpoint step (t : ITreeDefinition.itree L4 res_L4) : MlResult dvalue string
+CoFixpoint step (t : ITreeDefinition.itree L4 res_L4) : MlResult dvalue string
   := match observe t with
      | RetF (_,(_,(_,(_,x)))) => MlOk _ string x
      | TauF t => step t
      | VisF (inl1 e) k =>
          MlError _ string "Uninterpreted external call"
      | VisF (inr1 (inl1 (ThrowOOM msg))) k =>
-         MlError _ string ("OOM: " ++ msg)%string
-     | VisF (inr1 (inr1 (inl1 (ThrowUB msg)))) k =>
-         MlError _ string ("UB: " ++ msg)%string
-     | VisF (inr1 (inr1 (inr1 (inl1 (Debug msg))))) k =>
-         MlError _ string ("Debug: " ++ msg)%string
-     | VisF (inr1 (inr1 (inr1 (inr1 (LLVMEvents.Throw msg))))) k =>
-         MlError _ string ("Failure: " ++ msg)%string
+         MlError _ string ("OOM")%string
+     | VisF (inr1 (inr1 (inl1 (LLVMExc _)))) k =>
+         MlError _ string ("UB")%string
+     | VisF (inr1 (inr1 (inr1 (inl1 (ThrowUB _))))) k =>
+         MlError _ string ("UB")%string
+     | VisF (inr1 (inr1 (inr1 (inr1 (inl1 (Debug _)))))) k =>
+         MlError _ string ("Debug")%string
+     | VisF (inr1 (inr1 (inr1 (inr1 (inr1 (LLVMEvents.Throw _)))))) k =>
+         MlError _ string ("Failure")%string
      end.
 Set Guard Checking.
 
 (** Top level interpreter to run LLVM programs. Yields either a uvalue, or an error string. *)
 Definition interpret (prog : list (toplevel_entity typ (block typ * list (block typ)))) : MlResult dvalue string
-  := step (interpreter prog).
+  := step (interpreter nil prog).
 
 Axiom to_caml_str : string -> string.
 Extract Constant to_caml_str =>
@@ -149,17 +150,38 @@ Extract Constant llc_command_ocaml =>
                 close_out f;
                 Sys.command (""clang -lm -Wno-everything "" ^ llvm_file_name ^ "" -o "" ^ test_binary ^ "" && "" ^ test_binary)".
 
+(** Write our LLVM program to a file ("temporary_vellvm.ll"), and then
+    use the vellvm binary in the path to interpret this file in order
+    to get the return code. *)
+Axiom vellvm_binary_command_ocaml : string -> oint.
+Extract Constant vellvm_binary_command_ocaml =>
+          "fun prog ->
+              let llvm_file_name = Filename.(concat (get_temp_dir_name ()) ""temporary_vellvm.ll"") in
+              let test_binary = Filename.(concat (get_temp_dir_name ()) ""vellvmqc"") in
+              let f = open_out llvm_file_name in
+                Printf.fprintf f ""%s"" prog;
+                close_out f;
+                Sys.command (""./vellvm -interpret "" ^ llvm_file_name ^ "" | grep terminated | awk '{ exit $NF }'"")".
 
-Definition llc_command (prog : string) : int
+Definition llc_command (prog : string) : int_ast
   := oint_to_Z (llc_command_ocaml prog).
+
+Definition vellvm_binary_command (prog : string) : int_ast
+  := oint_to_Z (vellvm_binary_command_ocaml prog).
 
 Axiom vellvm_print_ll : list (toplevel_entity typ (block typ * list (block typ))) -> string.
 Extract Constant vellvm_print_ll => "fun prog -> Llvm_printer.toplevel_entities Format.str_formatter prog; Format.flush_str_formatter".
 
 (** Use the *llc_command* Axiom to run a Vellvm program with clang,
-    and wrap up the exit code as a uvalue. *)
+    and wrap up the exit code as a dvalue. *)
 Definition run_llc (prog : list (toplevel_entity typ (block typ * list (block typ)))) : dvalue
-  := DVALUE_I8 (repr (llc_command (to_caml_str (show prog)))).
+  := @DVALUE_I 8 (VellvmIntegers.repr (llc_command (to_caml_str (show prog)))).
+
+(** Use the *vellvm_binary_command* Axiom to run a Vellvm program with
+    the vellvm interpreter in the user's path, and wrap up the exit
+    code as a dvalue. *)
+Definition run_vellvm_binary (prog : list (toplevel_entity typ (block typ * list (block typ)))) : dvalue
+  := @DVALUE_I 8 (VellvmIntegers.repr (vellvm_binary_command (to_caml_str (show prog)))).
 
 (* Hide show instance... *)
 Inductive PROG :=
@@ -169,8 +191,6 @@ Inductive PROG :=
 #[global] Instance Show_PROG : Show PROG :=
   { show p := "" (* PROG: avoiding inefficient printing in QC, see #253 *) }.
 
-Definition gen_PROG : GenLLVM PROG
-  := fmap Prog gen_llvm.
 
 (** Basic property to make sure that Vellvm and Clang agree when they
     both produce values *)
@@ -186,7 +206,7 @@ Definition vellvm_agrees_with_clang_parallel (p : PROG) : Checker
     let vellvm_res := interpret prog in
     let clang_res := snd (waitpid nil pid) in
     match vellvm_res, clang_res with
-    | MlOk _ _ (DVALUE_I8 x), (WEXITED ocaml_y) =>
+    | MlOk _ _ (@DVALUE_I sz x), (WEXITED ocaml_y) =>
         let y := repr (oint_to_Z ocaml_y) in
         if equ x y
         then checker true
@@ -199,33 +219,93 @@ Definition vellvm_agrees_with_clang_parallel (p : PROG) : Checker
         whenFail ("Something else went wrong... Vellvm: " ++ show vellvm_res ++ " | Clang: " ++ show clang_res) false
     end.
 
+#[global] Instance Show_sum {A B} `{Show A} `{Show B} : Show (A + B) :=
+  { show :=  (fun x =>
+    match x with
+    | inl a => ("inl " ++ show a)%string
+    | inr b => ("inr " ++ show b)%string
+    end) }.
+
 (** Basic property to make sure that Vellvm and Clang agree when they
     both produce values *)
-Definition vellvm_agrees_with_clang (p : PROG) : Checker
-  :=
-  (* collect (show prog) *)
-  let '(Prog prog) := p in
-  let clang_res := run_llc prog in
-  let vellvm_res := interpret prog in
-  match clang_res, vellvm_res with
-  | DVALUE_I8 y, MlOk _ _ (DVALUE_I8 x) =>
-      if equ x y
-      then checker true
-      else whenFail ("Vellvm: " ++ show (unsigned x) ++ " | Clang: " ++ show (unsigned y) ++ " | Ast: " ++ ReprAST.repr prog) false
-  | _, _ =>
-      whenFail ("Something else went wrong... Vellvm: " ++ show vellvm_res ++ " | Clang: " ++ show clang_res) false
-  end.
+Definition vellvm_agrees_with_clang (p : string + PROG) : Checker.
+  refine
+    (match p with
+     | inl msg => checker false
+     | inr p =>
+         (* collect (show prog) *)
+         let '(Prog prog) := p in
+         let clang_res := run_llc prog in
+         let vellvm_res := interpret prog in
+         match clang_res, vellvm_res with
+         | @DVALUE_I sz1 y, MlOk _ _ (@DVALUE_I sz2 x) =>
+             _
+         | _, _ =>
+             whenFail ("Something else went wrong... Vellvm: " ++ show vellvm_res ++ " | Clang: " ++ show clang_res) false
+         end
+     end).
+
+  destruct ((Pos.eqb sz1 8%positive && Pos.eqb sz2 8%positive)%bool) eqn:SZ.
+  - invert_bools.
+    apply Peqb_true_eq in H, H0; subst.
+    destruct (equ x y) eqn:EQ.
+    + exact (checker true).
+    + exact (whenFail ("Vellvm: " ++ show (unsigned x) ++ " | Clang: " ++ show (unsigned y) ++ " | Ast: " ++ ReprAST.repr prog) false).
+  - exact (whenFail ("Vellvm: " ++ show (unsigned x) ++ " | Clang: " ++ show (unsigned y) ++ " | Ast: " ++ ReprAST.repr prog) false).
+Defined.
+
+(** This version runs the vellvm binary in your path instead...  This
+    will be slower (has to read and parse a file), and will not
+    guarantee you're running the tests with same version of vellvm, but
+    this can be helpful for testing the parser (note the more direct
+    vellvm_agrees_with_clang is also helpful in that it bypasses the
+    parser for vellvm, but clang parses the file so it can detect bugs
+    in the pretty printer for LLVM ASTs), and this can also be helpful
+    for skirting around extraction bugs which are easier to patch up
+    outside of QC. *)
+Definition vellvm_binary_agrees_with_clang (p : string + PROG) : Checker.
+  refine
+    (match p with
+     | inl msg => checker false
+     | inr p =>
+         (* collect (show prog) *)
+         let '(Prog prog) := p in
+         let clang_res := run_llc prog in
+         let vellvm_res := run_vellvm_binary prog in
+         match clang_res, vellvm_res with
+         | @DVALUE_I sz1 y, @DVALUE_I sz2 x =>
+             _
+         | _, _ =>
+             whenFail ("Something else went wrong... Vellvm: " ++ show vellvm_res ++ " | Clang: " ++ show clang_res) false
+         end
+     end).
+
+  destruct ((Pos.eqb sz1 8%positive && Pos.eqb sz2 8%positive)%bool) eqn:SZ.
+  - invert_bools.
+    apply Peqb_true_eq in H, H0; subst.
+    destruct (equ x y) eqn:EQ.
+    + exact (checker true).
+    + exact (whenFail ("Vellvm: " ++ show (unsigned x) ++ " | Clang: " ++ show (unsigned y) ++ " | Ast: " ++ ReprAST.repr prog) false).
+  - exact (whenFail ("Vellvm: " ++ show (unsigned x) ++ " | Clang: " ++ show (unsigned y) ++ " | Ast: " ++ ReprAST.repr prog) false).
+Defined.
+
+Definition gen_PROG : GenLLVM PROG
+  := fmap Prog gen_llvm.
 
 (* Definition agrees := (forAll (run_GenLLVM gen_llvm) vellvm_agrees_with_clang). *)
 
-Extract Constant defNumTests    => "5000".
-QCInclude "../../ml/*".
-QCInclude "../../ml/libvellvm/*".
+Extract Constant defNumTests    => "1000".
+
+(* SAZ: These paths are relative to where the coqc command that runs the extraction is executed.
+   For invoking `make qc-tests` from the `/src` directory, we need these:
+*)
+QCInclude "ml/*".
+QCInclude "ml/libvellvm/*".
 
 
 (* QCInclude "../../ml/libvellvm/llvm_printer.ml". *)
 (* QCInclude "../../ml/libvellvm/Camlcoq.ml". *)
 (* QCInclude "../../ml/extracted/*ml". *)
 Extract Inlined Constant Error.failwith => "(fun _ -> raise)".
-QuickChick (forAll (run_GenLLVM gen_PROG) vellvm_agrees_with_clang).
+QuickChick (forAll (run_GenLLVM gen_PROG) vellvm_binary_agrees_with_clang).
 (*! QuickChick agrees. *)

--- a/src/rocq/QCVellvm.v
+++ b/src/rocq/QCVellvm.v
@@ -179,7 +179,7 @@ CoFixpoint step (t : itr) : MlResult dvalue string
      | VisF _ (inr1 (inl1 (ThrowOOM msg))) k =>
          MlError _ string ("OOM")%string
      | VisF _ (inr1 (inr1 (inl1 (LLVMExc _)))) k =>
-         MlError _ string ("UB")%string
+         MlError _ string ("LLVMException")%string
      | VisF _ (inr1 (inr1 (inr1 (inl1 (ThrowUB _))))) k =>
          MlError _ string ("UB")%string
      | VisF _ (inr1 (inr1 (inr1 (inr1 (inl1 (Debug _)))))) k =>

--- a/src/rocq/QCVellvm.v
+++ b/src/rocq/QCVellvm.v
@@ -1,84 +1,45 @@
- (** Framework for running QC vellvm tests.
+ (** Framework for running QC vellvm tests. *)
 
-    This sets up a step function which mimics the step function in
-    interpreter.ml in Coq. This function may not terminate (e.g., when
-    given an LLVM program that loops forever), and as such we need to
-    disable the Coq termination checker to define it.
- *)
-Require Import Semantics.LLVMEvents.
-Require Import Semantics.InterpretationStack.
-Require Import Handlers.Handlers.
+From QuickChick Require Import QuickChick.
+From Stdlib Require Import
+  String
+  ZArith
+  List.
+From Vellvm Require Import
+  LLVMAst
+  Syntax.ShowAST
+  Syntax.ReprAST.
+From GenLLVM Require Import
+  GenAST.
 
-From Stdlib Require Import String.
-From Stdlib Require Import ZArith.
-
-From ITree Require Import
-     ITree
-     Interp.Recursion
-     Events.Exception.
-
-(* Require Import ExtrOcamlBasic. *)
-(* Require Import ExtrOcamlString. *)
-
-(* From QuickChick Require Import QuickChick. *)
-From QuickChick Require Import Show Checker Generators Producer Test.
-From Vellvm Require Import ShowAST ReprAST GenAST TopLevel LLVMAst DynamicValues VellvmIntegers.
+Import ListNotations.
+Local Open Scope string_scope.
 
 Extraction Blacklist String List Char Core Z Format int.
 
-(* TODO: Use the existing vellvm version of this? Might actually just be ocaml result type. *)
-Inductive MlResult a e :=
-| MlOk : a -> MlResult a e
-| MlError : e -> MlResult a e.
+(* Useful names *)
+Definition lprog := list (toplevel_entity typ (block typ * list (block typ))).
 
-Extract Inductive MlResult => "result" [ "Ok" "Error" ].
+#[global] Instance show_lprog : Show lprog :=
+  {| show := showProg |}.
 
-#[global] Instance MlResultShow {a e} `{Show a} `{Show e} : Show (MlResult a e).
-Proof.
-  split.
-  exact
-    (fun res =>
-       match res with
-       | MlOk _ _ a => ("Ok " ++ show a)%string
-       | MlError _ _ e => ("Error " ++ show e)%string
-       end).
-Defined.
+(* Hide show instance... *)
+Inductive PROG :=
+| Prog : lprog -> PROG
+.
 
-Import TopLevel64BitIntptr.
-(* Import TopLevelBigIntptr. *)
-Import DV.
-Import MemoryModelImplementation.LLVMParams64BitIntptr.Events.
-(* Import MemoryModelImplementation.LLVMParamsBigIntptr.Events. *)
+#[global] Instance Show_PROG : Show PROG :=
+  { show p := "" (* PROG: avoiding inefficient printing in QC, see #253 *) }.
 
-#[global] Instance showdv : Show dvalue.
-Proof.
-  split.
-  apply show_dvalue.
-Defined.
+#[global] Instance Show_sum {A B} `{Show A} `{Show B} : Show (A + B) :=
+  { show :=  (fun x =>
+    match x with
+    | inl a => ("inl " ++ show a)%string
+    | inr b => ("inr " ++ show b)%string
+    end) }.
 
-Unset Guard Checking.
-CoFixpoint step (t : ITreeDefinition.itree L4 res_L4) : MlResult dvalue string
-  := match observe t with
-     | RetF (_,(_,(_,(_,x)))) => MlOk _ string x
-     | TauF t => step t
-     | VisF (inl1 e) k =>
-         MlError _ string "Uninterpreted external call"
-     | VisF (inr1 (inl1 (ThrowOOM msg))) k =>
-         MlError _ string ("OOM")%string
-     | VisF (inr1 (inr1 (inl1 (LLVMExc _)))) k =>
-         MlError _ string ("UB")%string
-     | VisF (inr1 (inr1 (inr1 (inl1 (ThrowUB _))))) k =>
-         MlError _ string ("UB")%string
-     | VisF (inr1 (inr1 (inr1 (inr1 (inl1 (Debug _)))))) k =>
-         MlError _ string ("Debug")%string
-     | VisF (inr1 (inr1 (inr1 (inr1 (inr1 (LLVMEvents.Throw _)))))) k =>
-         MlError _ string ("Failure")%string
-     end.
-Set Guard Checking.
-
-(** Top level interpreter to run LLVM programs. Yields either a uvalue, or an error string. *)
-Definition interpret (prog : list (toplevel_entity typ (block typ * list (block typ)))) : MlResult dvalue string
-  := step (interpreter nil prog).
+Definition gen_PROG : GenLLVM PROG
+  := fmap Prog gen_llvm.
 
 Axiom to_caml_str : string -> string.
 Extract Constant to_caml_str =>
@@ -105,38 +66,6 @@ Extract Inlined Constant oeq => "(=)".
 Axiom ozero : oint.
 Extract Inlined Constant ozero => "0".
 
-(** Processes *)
-Inductive process_status : Type :=
-| WEXITED   : oint -> process_status
-| WSIGNALED : oint -> process_status
-| WSTOPPED  : oint -> process_status
-.
-Extract Inductive process_status => "process_status" [ "WEXITED" "WSIGNALED" "WSTOPPED" ].
-
-#[global] Instance Show_process_status : Show process_status.
-Proof.
-  split.
-  intros STATUS. destruct STATUS as [EXIT | SIGNAL | STOPPED].
-  - exact ("Exited with " ++ show (oint_to_Z EXIT))%string.
-  - exact ("Signaled with " ++ show (oint_to_Z SIGNAL))%string.
-  - exact ("Stopped with " ++ show (oint_to_Z STOPPED))%string.
-Qed.
-
-Axiom fork : unit -> oint.
-Extract Inlined Constant fork => "Unix.fork".
-
-Axiom wait : unit -> (oint * process_status)%type.
-Extract Inlined Constant wait => "Unix.wait".
-
-Axiom wait_flag : Type.
-Extract Inlined Constant wait_flag => "Unix.wait_flag".
-
-Axiom waitpid : list wait_flag -> oint -> (oint * process_status)%type.
-Extract Inlined Constant waitpid => "Unix.waitpid".
-
-Axiom exit : forall {A}, oint -> A.
-Extract Inlined Constant exit => "exit".
-
 (** Write our LLVM program to a file ("temporary_vellvm.ll"), and then
     use clang to compile this file to an executable, which we then run in
     order to get the return code. *)
@@ -156,103 +85,28 @@ Extract Constant llc_command_ocaml =>
 Axiom vellvm_binary_command_ocaml : string -> oint.
 Extract Constant vellvm_binary_command_ocaml =>
           "fun prog ->
+              let vellvm_bin = (try Sys.getenv ""VELLVM_BIN""
+                                with Not_found -> ""../vellvm/src/_build/default/ml/main.exe"") in
               let llvm_file_name = Filename.(concat (get_temp_dir_name ()) ""temporary_vellvm.ll"") in
-              let test_binary = Filename.(concat (get_temp_dir_name ()) ""vellvmqc"") in
               let f = open_out llvm_file_name in
                 Printf.fprintf f ""%s"" prog;
                 close_out f;
-                Sys.command (""./vellvm -interpret "" ^ llvm_file_name ^ "" | grep terminated | awk '{ exit $NF }'"")".
+                Sys.command (vellvm_bin ^ "" -interpret "" ^ llvm_file_name ^ "" | grep terminated | awk '{ exit $NF }'"")".
 
-Definition llc_command (prog : string) : int_ast
+Definition llc_command (prog : string) : Z
   := oint_to_Z (llc_command_ocaml prog).
 
-Definition vellvm_binary_command (prog : string) : int_ast
+Definition vellvm_binary_command (prog : string) : Z
   := oint_to_Z (vellvm_binary_command_ocaml prog).
 
-Axiom vellvm_print_ll : list (toplevel_entity typ (block typ * list (block typ))) -> string.
-Extract Constant vellvm_print_ll => "fun prog -> Llvm_printer.toplevel_entities Format.str_formatter prog; Format.flush_str_formatter".
-
-(** Use the *llc_command* Axiom to run a Vellvm program with clang,
-    and wrap up the exit code as a dvalue. *)
-Definition run_llc (prog : list (toplevel_entity typ (block typ * list (block typ)))) : dvalue
-  := @DVALUE_I 8 (VellvmIntegers.repr (llc_command (to_caml_str (show prog)))).
+(** Use the *llc_command* Axiom to run a Vellvm program with clang. *)
+Definition run_llc (prog : lprog) : Z
+  := llc_command (to_caml_str (show prog)).
 
 (** Use the *vellvm_binary_command* Axiom to run a Vellvm program with
-    the vellvm interpreter in the user's path, and wrap up the exit
-    code as a dvalue. *)
-Definition run_vellvm_binary (prog : list (toplevel_entity typ (block typ * list (block typ)))) : dvalue
-  := @DVALUE_I 8 (VellvmIntegers.repr (vellvm_binary_command (to_caml_str (show prog)))).
-
-(* Hide show instance... *)
-Inductive PROG :=
-| Prog : list (toplevel_entity typ (block typ * list (block typ))) -> PROG
-.
-
-#[global] Instance Show_PROG : Show PROG :=
-  { show p := "" (* PROG: avoiding inefficient printing in QC, see #253 *) }.
-
-
-(** Basic property to make sure that Vellvm and Clang agree when they
-    both produce values *)
-Definition vellvm_agrees_with_clang_parallel (p : PROG) : Checker
-  :=
-  (* collect (show prog) *)
-  let '(Prog prog) := p in
-  let pid := fork tt in
-  if oeq pid ozero
-  then (* Child *)
-    exit (llc_command_ocaml (to_caml_str (show prog)))
-  else (* Parent *)
-    let vellvm_res := interpret prog in
-    let clang_res := snd (waitpid nil pid) in
-    match vellvm_res, clang_res with
-    | MlOk _ _ (@DVALUE_I sz x), (WEXITED ocaml_y) =>
-        let y := repr (oint_to_Z ocaml_y) in
-        if equ x y
-        then checker true
-        else whenFail ("Vellvm: " ++ show (unsigned x) ++ " | Clang: " ++ show (unsigned y) ++ " | Ast: " ++ ReprAST.repr prog) false
-    | _, (WSIGNALED ocaml_y) =>
-        whenFail ("clang process signaled") false
-    | _, (WSTOPPED ocaml_y) =>
-        whenFail ("clang process stopped") false
-    | _, _ =>
-        whenFail ("Something else went wrong... Vellvm: " ++ show vellvm_res ++ " | Clang: " ++ show clang_res) false
-    end.
-
-#[global] Instance Show_sum {A B} `{Show A} `{Show B} : Show (A + B) :=
-  { show :=  (fun x =>
-    match x with
-    | inl a => ("inl " ++ show a)%string
-    | inr b => ("inr " ++ show b)%string
-    end) }.
-
-(** Basic property to make sure that Vellvm and Clang agree when they
-    both produce values *)
-Definition vellvm_agrees_with_clang (p : string + PROG) : Checker.
-  refine
-    (match p with
-     | inl msg => checker false
-     | inr p =>
-         (* collect (show prog) *)
-         let '(Prog prog) := p in
-         let clang_res := run_llc prog in
-         let vellvm_res := interpret prog in
-         match clang_res, vellvm_res with
-         | @DVALUE_I sz1 y, MlOk _ _ (@DVALUE_I sz2 x) =>
-             _
-         | _, _ =>
-             whenFail ("Something else went wrong... Vellvm: " ++ show vellvm_res ++ " | Clang: " ++ show clang_res) false
-         end
-     end).
-
-  destruct ((Pos.eqb sz1 8%positive && Pos.eqb sz2 8%positive)%bool) eqn:SZ.
-  - invert_bools.
-    apply Peqb_true_eq in H, H0; subst.
-    destruct (equ x y) eqn:EQ.
-    + exact (checker true).
-    + exact (whenFail ("Vellvm: " ++ show (unsigned x) ++ " | Clang: " ++ show (unsigned y) ++ " | Ast: " ++ ReprAST.repr prog) false).
-  - exact (whenFail ("Vellvm: " ++ show (unsigned x) ++ " | Clang: " ++ show (unsigned y) ++ " | Ast: " ++ ReprAST.repr prog) false).
-Defined.
+    the vellvm interpreter in the user's path. *)
+Definition run_vellvm_binary (prog : lprog) : Z
+  := vellvm_binary_command (to_caml_str (show prog)).
 
 (** This version runs the vellvm binary in your path instead...  This
     will be slower (has to read and parse a file), and will not
@@ -272,40 +126,15 @@ Definition vellvm_binary_agrees_with_clang (p : string + PROG) : Checker.
          let '(Prog prog) := p in
          let clang_res := run_llc prog in
          let vellvm_res := run_vellvm_binary prog in
-         match clang_res, vellvm_res with
-         | @DVALUE_I sz1 y, @DVALUE_I sz2 x =>
-             _
-         | _, _ =>
-             whenFail ("Something else went wrong... Vellvm: " ++ show vellvm_res ++ " | Clang: " ++ show clang_res) false
-         end
+         if (Z.eqb clang_res vellvm_res)
+         then checker true
+         else whenFail ("Vellvm: " ++ show vellvm_res ++ " | Clang: " ++ show clang_res ++ " | Ast: " ++ ReprAST.repr prog) false
      end).
-
-  destruct ((Pos.eqb sz1 8%positive && Pos.eqb sz2 8%positive)%bool) eqn:SZ.
-  - invert_bools.
-    apply Peqb_true_eq in H, H0; subst.
-    destruct (equ x y) eqn:EQ.
-    + exact (checker true).
-    + exact (whenFail ("Vellvm: " ++ show (unsigned x) ++ " | Clang: " ++ show (unsigned y) ++ " | Ast: " ++ ReprAST.repr prog) false).
-  - exact (whenFail ("Vellvm: " ++ show (unsigned x) ++ " | Clang: " ++ show (unsigned y) ++ " | Ast: " ++ ReprAST.repr prog) false).
 Defined.
-
-Definition gen_PROG : GenLLVM PROG
-  := fmap Prog gen_llvm.
 
 (* Definition agrees := (forAll (run_GenLLVM gen_llvm) vellvm_agrees_with_clang). *)
 
 Extract Constant defNumTests    => "1000".
 
-(* SAZ: These paths are relative to where the coqc command that runs the extraction is executed.
-   For invoking `make qc-tests` from the `/src` directory, we need these:
-*)
-QCInclude "ml/*".
-QCInclude "ml/libvellvm/*".
-
-
-(* QCInclude "../../ml/libvellvm/llvm_printer.ml". *)
-(* QCInclude "../../ml/libvellvm/Camlcoq.ml". *)
-(* QCInclude "../../ml/extracted/*ml". *)
-Extract Inlined Constant Error.failwith => "(fun _ -> raise)".
 QuickChick (forAll (run_GenLLVM gen_PROG) vellvm_binary_agrees_with_clang).
 (*! QuickChick agrees. *)

--- a/src/rocq/QCVellvm.v
+++ b/src/rocq/QCVellvm.v
@@ -10,7 +10,8 @@ From Vellvm Require Import
   Syntax.ShowAST
   Syntax.ReprAST.
 From GenLLVM Require Import
-  GenAST.
+  GenAST
+  QCExtractionFix.
 
 Import ListNotations.
 Local Open Scope string_scope.

--- a/src/rocq/QCVellvm.v
+++ b/src/rocq/QCVellvm.v
@@ -6,12 +6,22 @@ From Stdlib Require Import
   ZArith
   List.
 From Vellvm Require Import
+  Params
   LLVMAst
   Syntax.ShowAST
-  Syntax.ReprAST.
+  Syntax.ReprAST
+  Semantics.LLVMEvents
+  Semantics.InterpretationStack
+  Semantics.DynamicValues
+  ParamsV
+  IPtrInfinite.
 From GenLLVM Require Import
   GenAST
   QCExtractionFix.
+From ITree Require Import
+     ITree
+     Interp.Recursion
+     Events.Exception.
 
 Import ListNotations.
 Local Open Scope string_scope.
@@ -19,14 +29,14 @@ Local Open Scope string_scope.
 Extraction Blacklist String List Char Core Z Format int.
 
 (* Useful names *)
-Definition lprog := list (toplevel_entity typ (block typ * list (block typ))).
+Definition llprog := list (toplevel_entity typ (block typ * list (block typ))).
 
-#[global] Instance show_lprog : Show lprog :=
+#[global] Instance show_lprog : Show llprog :=
   {| show := showProg |}.
 
 (* Hide show instance... *)
 Inductive PROG :=
-| Prog : lprog -> PROG
+| Prog : llprog -> PROG
 .
 
 #[global] Instance Show_PROG : Show PROG :=
@@ -101,12 +111,12 @@ Definition vellvm_binary_command (prog : string) : Z
   := oint_to_Z (vellvm_binary_command_ocaml prog).
 
 (** Use the *llc_command* Axiom to run a Vellvm program with clang. *)
-Definition run_llc (prog : lprog) : Z
+Definition run_llc (prog : llprog) : Z
   := llc_command (to_caml_str (show prog)).
 
 (** Use the *vellvm_binary_command* Axiom to run a Vellvm program with
     the vellvm interpreter in the user's path. *)
-Definition run_vellvm_binary (prog : lprog) : Z
+Definition run_vellvm_binary (prog : llprog) : Z
   := vellvm_binary_command (to_caml_str (show prog)).
 
 (** This version runs the vellvm binary in your path instead...  This
@@ -118,24 +128,156 @@ Definition run_vellvm_binary (prog : lprog) : Z
     in the pretty printer for LLVM ASTs), and this can also be helpful
     for skirting around extraction bugs which are easier to patch up
     outside of QC. *)
-Definition vellvm_binary_agrees_with_clang (p : string + PROG) : Checker.
-  refine
-    (match p with
-     | inl msg => checker false
-     | inr p =>
-         (* collect (show prog) *)
-         let '(Prog prog) := p in
-         let clang_res := run_llc prog in
-         let vellvm_res := run_vellvm_binary prog in
-         if (Z.eqb clang_res vellvm_res)
-         then checker true
-         else whenFail ("Vellvm: " ++ show vellvm_res ++ " | Clang: " ++ show clang_res ++ " | Ast: " ++ ReprAST.repr prog) false
-     end).
+Definition vellvm_binary_agrees_with_clang (p : string + PROG) : Checker :=
+  match p with
+  | inl msg => checker false
+  | inr (Prog prog) =>
+    let clang_res := run_llc prog in
+    let vellvm_res := run_vellvm_binary prog in
+    if (Z.eqb clang_res vellvm_res)
+    then checker true
+    else whenFail ("Vellvm: " ++ show vellvm_res ++ " | Clang: " ++ show clang_res ++ " | Ast: " ++ ReprAST.repr prog) false
+  end.
+
+(* In-process testing *)
+
+#[local] Instance ParamsQC : Params := @ParamsV IPZ IPZTheory.
+
+Inductive MlResult (a e: Type) :=
+| MlOk : a -> MlResult a e
+| MlError : e -> MlResult a e.
+
+Extract Inductive MlResult => "result" [ "Ok" "Error" ].
+
+#[global] Instance MlResultShow {a e} `{Show a} `{Show e} : Show (MlResult a e).
+Proof.
+  split.
+  exact
+    (fun res =>
+       match res with
+       | MlOk a => ("Ok " ++ show a)%string
+       | MlError e => ("Error " ++ show e)%string
+       end).
 Defined.
+
+#[global] Instance showdv : Show dvalue.
+Proof.
+  split.
+  apply show_dvalue.
+Defined.
+
+Local Notation dvalue := DynamicValues.dvalue.
+Local Notation itr := (itree MCFGEbot (Res dvalue)).
+
+Unset Guard Checking.
+CoFixpoint step (t : itr) : MlResult dvalue string
+  := match observe t with
+     | RetF (_, x) => MlOk _ string x
+     | TauF t => step t
+     | VisF _ (inl1 e) k =>
+         MlError _ string "Uninterpreted external call"
+     | VisF _ (inr1 (inl1 (ThrowOOM msg))) k =>
+         MlError _ string ("OOM")%string
+     | VisF _ (inr1 (inr1 (inl1 (LLVMExc _)))) k =>
+         MlError _ string ("UB")%string
+     | VisF _ (inr1 (inr1 (inr1 (inl1 (ThrowUB _))))) k =>
+         MlError _ string ("UB")%string
+     | VisF _ (inr1 (inr1 (inr1 (inr1 (inl1 (Debug _)))))) k =>
+         MlError _ string ("Debug")%string
+     | VisF _ (inr1 (inr1 (inr1 (inr1 (inr1 (LLVMEvents.Throw _)))))) k =>
+         MlError _ string ("Failure")%string
+     end.
+Set Guard Checking.
+
+(** Top level interpreter to run LLVM programs. Yields either a uvalue, or an error string. *)
+Definition interpret (prog : llprog) : MlResult dvalue string
+  := step (TopLevel.interpreter nil prog).
+
+(** Basic property to make sure that Vellvm and Clang agree when they
+    both produce values *)
+Definition vellvm_agrees_with_clang (p : string + PROG) : Checker :=
+  match p with
+  | inl msg => checker false
+  | inr (Prog prog) =>
+    let clang_res := run_llc prog in
+    let vellvm_res := interpret prog in
+    match vellvm_res with
+    | MlOk (DVALUE_Base (DVALUE_I sz x)) =>
+      if ((Pos.eqb sz 8%positive && Z.eqb (Integers.unsigned x) clang_res)%bool)
+      then checker true
+      else whenFail ("Vellvm: " ++ show (Integers.unsigned x)
+                      ++ " | Clang: " ++ show clang_res
+                      ++ " | Ast: " ++ ReprAST.repr prog) false
+    | _ => whenFail ("Something else went wrong... Vellvm: " ++ show vellvm_res
+                      ++ " | Clang: " ++ show clang_res
+                      ++ " | Ast: " ++ ReprAST.repr prog) false
+    end
+  end.
+
+(** Processes *)
+Inductive process_status : Type :=
+| WEXITED   : oint -> process_status
+| WSIGNALED : oint -> process_status
+| WSTOPPED  : oint -> process_status
+.
+Extract Inductive process_status => "Unix.process_status" [ "Unix.WEXITED" "Unix.WSIGNALED" "Unix.WSTOPPED" ].
+
+#[global] Instance Show_process_status : Show process_status.
+Proof.
+  split.
+  intros STATUS. destruct STATUS as [EXIT | SIGNAL | STOPPED].
+  - exact ("Exited with " ++ show (oint_to_Z EXIT))%string.
+  - exact ("Signaled with " ++ show (oint_to_Z SIGNAL))%string.
+  - exact ("Stopped with " ++ show (oint_to_Z STOPPED))%string.
+Qed.
+
+Axiom fork : unit -> oint.
+Extract Inlined Constant fork => "Unix.fork".
+
+Axiom wait : unit -> (oint * process_status)%type.
+Extract Inlined Constant wait => "Unix.wait".
+
+Axiom wait_flag : Type.
+Extract Inlined Constant wait_flag => "Unix.wait_flag".
+
+Axiom waitpid : list wait_flag -> oint -> (oint * process_status)%type.
+Extract Inlined Constant waitpid => "Unix.waitpid".
+
+Axiom exit : forall {A}, oint -> A.
+Extract Inlined Constant exit => "exit".
+
+(** Basic property to make sure that Vellvm and Clang agree when they
+    both produce values *)
+Definition vellvm_agrees_with_clang_parallel (p : string + PROG) : Checker :=
+  match p with
+  | inl msg => checker false
+  | inr (Prog prog) =>
+    let pid := fork tt in
+    if oeq pid ozero
+    then (* Child *)
+      exit (llc_command_ocaml (to_caml_str (show prog)))
+    else (* Parent *)
+      let vellvm_res := interpret prog in
+      let clang_res := snd (waitpid nil pid) in
+      match vellvm_res, clang_res with
+      | MlOk (DVALUE_Base (DVALUE_I sz x)), (WEXITED ocaml_y) =>
+          let y := Integers.repr (oint_to_Z ocaml_y) in
+          if Integers.eq x y
+          then checker true
+          else whenFail ("Vellvm: " ++ show (Integers.unsigned x) ++ " | Clang: " ++ show (Integers.unsigned y) ++ " | Ast: " ++ ReprAST.repr prog) false
+      | _, (WSIGNALED ocaml_y) =>
+          whenFail ("clang process signaled") false
+      | _, (WSTOPPED ocaml_y) =>
+          whenFail ("clang process stopped") false
+      | _, _ =>
+          whenFail ("Something else went wrong... Vellvm: " ++ show vellvm_res ++ " | Clang: " ++ show clang_res) false
+      end
+  end.
 
 (* Definition agrees := (forAll (run_GenLLVM gen_llvm) vellvm_agrees_with_clang). *)
 
 Extract Constant defNumTests    => "1000".
 
 QuickChick (forAll (run_GenLLVM gen_PROG) vellvm_binary_agrees_with_clang).
-(*! QuickChick agrees. *)
+(* QuickChick (forAll (run_GenLLVM gen_PROG) vellvm_agrees_with_clang). *)
+(* QuickChick (forAll (run_GenLLVM gen_PROG) vellvm_agrees_with_clang_parallel). *)

--- a/src/rocq/TestCases.v
+++ b/src/rocq/TestCases.v
@@ -2,14 +2,13 @@
     and some lemmas related to them.
  *)
 From QuickChick Require Import QuickChick.
-From Vellvm Require Import ShowAST ReprAST TopLevel LLVMAst DynamicValues.
-From GenLLVM Require Import GenAST QCVellvm.
+From Vellvm Require Import ShowAST ReprAST GenAST QCVellvm TopLevel LLVMAst DynamicValues.
 Require Import Semantics.LLVMEvents.
 Require Import Semantics.InterpretationStack.
 Require Import Handlers.Handlers.
 
-Require Import String.
-Require Import ZArith.
+From Stdlib Require Import String.
+From Stdlib Require Import ZArith.
 
 From ITree Require Import
      ITree
@@ -19,7 +18,7 @@ From ITree Require Import
 Require Import ExtrOcamlBasic.
 Require Import ExtrOcamlString.
 
-Require Import List.
+From Stdlib Require Import List.
 Import ListNotations.
 
 
@@ -189,6 +188,7 @@ From Vellvm Require Import
      Syntax.CFG
      Syntax.Traversal
      Syntax.Scope
+     Syntax.ScopeTheory
      Syntax.TypToDtyp
      Semantics.InterpretationStack
      Semantics.TopLevel

--- a/src/rocq/TypeUtil.v
+++ b/src/rocq/TypeUtil.v
@@ -1,0 +1,64 @@
+(* From src/rocq/Syntax/TypeUtil.v of commit f1ec3588 *)
+
+From Stdlib Require Import
+     List
+     String.
+
+From Vellvm Require Import
+     Syntax.LLVMAst
+     Syntax.AstLib
+     Syntax.TypToDtyp
+     ListUtil.
+
+Require Import Rocqlib.
+
+Import ListNotations.
+Open Scope list_scope.
+
+Program Fixpoint normalize_type (env : list (ident * typ)) (t : typ) {measure (List.length env, t) (lex_ord lt typ_order)} : typ :=
+  match t with
+  | TYPE_Array sz t =>
+    let nt := normalize_type env t in
+    TYPE_Array sz nt
+
+  | TYPE_Function ret args varargs =>
+    let nret := (normalize_type env ret) in
+    let nargs := map_In args (fun t _ => normalize_type env t) in
+    TYPE_Function nret nargs varargs
+
+  | TYPE_Struct fields =>
+    let nfields := map_In fields (fun t _ => normalize_type env t) in
+    TYPE_Struct nfields
+
+  | TYPE_Packed_struct fields =>
+    let nfields := map_In fields (fun t _ => normalize_type env t) in
+    TYPE_Packed_struct nfields
+
+  | TYPE_Vector sz t =>
+    let nt := normalize_type env t in
+    TYPE_Vector sz nt
+
+  | TYPE_Identified id =>
+    match find (fun a => Ident.eq_dec id (fst a)) env with
+    | None => TYPE_Identified id
+    | Some (_, t) => normalize_type (remove_key Ident.eq_dec id env) t
+    end
+
+  | TYPE_I sz => t
+  | TYPE_Iptr => t
+  | TYPE_Pointer t' => t
+  | TYPE_Void => t
+  | TYPE_FP fp => t
+  | TYPE_Label => t
+  | TYPE_Token => t
+  | TYPE_Metadata => t
+  | TYPE_X86_mmx => t
+  | TYPE_Opaque => t
+  end.
+Next Obligation.
+  left.
+  symmetry in Heq_anonymous. apply find_some in Heq_anonymous. destruct Heq_anonymous as [Hin Heqb_ident].
+  simpl in Heqb_ident.
+  destruct (Ident.eq_dec id wildcard'). subst. eapply remove_key_in. apply Hin.
+  inversion Heqb_ident.
+Defined.

--- a/src/rocq/Utils.v
+++ b/src/rocq/Utils.v
@@ -1,8 +1,8 @@
 (** Some utility functions and lemmas for QC. *)
-Require Import Ceres.Ceres.
 
-From QuickChick Require Import QuickChick.
-Import QcDefaultNotation. Open Scope qc_scope.
+(* From QuickChick Require Import QuickChick. *)
+From QuickChick Require Import Generators Producer.
+Open Scope qc_scope.
 Set Warnings "-extraction-opaque-accessed,-extraction".
 
 From ExtLib.Structures Require Export
@@ -10,12 +10,11 @@ From ExtLib.Structures Require Export
 
 Require Import ExtLib.Data.Monads.StateMonad.
 
-From Vellvm Require Import LLVMAst Utils AstLib Syntax.CFG Semantics.TopLevel.
+From Vellvm Require Import LLVMAst Util AstLib Syntax.CFG.
 From Vellvm Require Import Semantics.DynamicValues.
 
 
 From Stdlib Require Import List.
-
 
 Import ListNotations.
 Import MonadNotation.
@@ -24,7 +23,6 @@ Import ApplicativeNotation.
 From Stdlib Require Import Lia.
 
 Open Scope Z_scope.
-
 
 Fixpoint max_nat_list (l : list nat) : nat :=
   match l with
@@ -35,8 +33,7 @@ Fixpoint max_nat_list (l : list nat) : nat :=
 (* TODO: how big should lists be? *)
 Fixpoint sizeof_typ (t : typ) : nat :=
   match t with
-  | TYPE_Pointer (Some t)            => S (sizeof_typ t)
-  | TYPE_Pointer None         => 0
+  | TYPE_Pointer (Some t)     => S (sizeof_typ t)
   | TYPE_Array sz t           => S (sizeof_typ t)
   | TYPE_Function ret args _  => max (sizeof_typ ret) (max_nat_list (map sizeof_typ args))
   | TYPE_Struct fields        => max_nat_list (map sizeof_typ fields)

--- a/src/rocq/Utils.v
+++ b/src/rocq/Utils.v
@@ -1,7 +1,7 @@
 (** Some utility functions and lemmas for QC. *)
 
 (* From QuickChick Require Import QuickChick. *)
-From QuickChick Require Import Generators Producer.
+From QuickChick Require Import Generators Producer Show.
 Open Scope qc_scope.
 Set Warnings "-extraction-opaque-accessed,-extraction".
 
@@ -10,7 +10,7 @@ From ExtLib.Structures Require Export
 
 Require Import ExtLib.Data.Monads.StateMonad.
 
-From Vellvm Require Import LLVMAst Util AstLib Syntax.CFG.
+From Vellvm Require Import LLVMAst AstLib Syntax.CFG Syntax.ShowAST.
 From Vellvm Require Import Semantics.DynamicValues.
 
 
@@ -23,6 +23,19 @@ Import ApplicativeNotation.
 From Stdlib Require Import Lia.
 
 Open Scope Z_scope.
+
+#[global] Instance Show_typ : Show typ :=
+  {| show := ShowAST.show_typ |}.
+
+(* From src/rocq/Utils/OptionUtil.v of commit f1ec3588 *)
+Definition maybe {a b} (def : b) (f : a -> b) (oa : option a) : b
+  := match oa with
+     | Some a => f a
+     | None => def
+     end.
+
+(* From src/rocq/Utils/Error.v of commit f1ec3588 *)
+Notation err := (sum String.string).
 
 Fixpoint max_nat_list (l : list nat) : nat :=
   match l with

--- a/src/rocq/Utils.v
+++ b/src/rocq/Utils.v
@@ -25,7 +25,7 @@ From Stdlib Require Import Lia.
 Open Scope Z_scope.
 
 #[global] Instance Show_typ : Show typ :=
-  {| show := ShowAST.show_typ |}.
+  {| show := show_typ |}.
 
 (* From src/rocq/Utils/OptionUtil.v of commit f1ec3588 *)
 Definition maybe {a b} (def : b) (f : a -> b) (oa : option a) : b


### PR DESCRIPTION
This PR makes `make qc-tests` work again on the current Vellvm main branch (`de5b3249`):
it generates random LLVM programs and runs differential testing between Vellvm's executable semantics and the binary compiled by clang.

What is in here:
- The generator (`GenAST.v`) and the files that go with it.
- The test scenarios of the original `QCVellvm.v`, rewritten for main: `vellvm_binary_agrees_with_clang`, `vellvm_agrees_with_clang` and `vellvm_agrees_with_clang_parallel`
- `GenAlive2.v`, `TestCases.v`, `QCShowTesting.v` and `Example.v` are not ported yet.

Found along the way:
1. QuickChick extraction bug: in QuickChick's `ExtractionQC.v`, the directives for `Number.int` and `Hexadecimal.int` write the match function with its arguments in the wrong order (see [link](https://rocq-prover.org/doc/V9.0.0/refman/addendum/extraction.html)). Because of this, every extracted program that matches on such a value dies with a segfault (code 139). `QCExtractionFix.v` writes the two directives again in the right order to cover the bug for now. You can see a minimal counterexample at this [link](https://github.com/petrosyh/genllvm/issues/1).
2. Float constants: `gen_float32_syntax` generates 8 random hex digits through `gen_hex 8`. However, my current LLVM version (22.1.8) has rules about the form and the value of float hex constants, and 8 random digits break them, so clang and Vellvm reject the program ("When using the hexadecimal form, constants of types bfloat, half, float, and double are represented using the 16-digit form shown above (which matches the IEEE754 representation for double); bfloat, half and float values must, however, be exactly representable as bfloat, IEEE 754 half, and IEEE 754 single precision respectively." from [LangRef](https://releases.llvm.org/22.1.0/docs/LangRef.html#simple-constants), [example link](https://github.com/petrosyh/genllvm/issues/2)). I fixed this in the generator: it reads the 32-bit pattern it made as a float32 value, and widens that value to a double bit pattern.

Known limitation:
Nothing discards UB right now. So when a run reaches UB, the testing campaign fails and the differential testing stops. This problem was already there in the test scenarios before the migration. It could be handled by discarding a case when the Vellvm semantics reports UB.

How to run:

`cd src && make qc-tests`